### PR TITLE
Add yarn berry and pnpm progress line patterns to BuildOutputProcessor

### DIFF
--- a/src/processors/build_output.py
+++ b/src/processors/build_output.py
@@ -274,8 +274,8 @@ class BuildOutputProcessor(Processor):
             r"^\s*Using\s+(cached|version)\b",
             r"^\s*Collecting\s+\S+",  # pip
             r"^\s*━",  # pip progress bar
-            r"^\s*(Resolution|Fetch|Link)\s+step\b",  # yarn berry v2+ step progress
+            r"^.*(Resolution|Fetch|Link)\s+step\b",  # yarn berry v2+ (prefixed with ➤ YN0000: ┌)
             r"^\s*Progress:\s+resolved\s+\d+",  # pnpm resolved/reused/downloaded stats
-            r"^\s*packages?\s+(are|is)\s+hard linked",  # pnpm content-addressable store
+            r"^\s*[Pp]ackages?\s+(are|is)\s+hard linked",  # pnpm content-addressable store
         ]
         return any(re.match(p, line) for p in patterns)

--- a/src/processors/build_output.py
+++ b/src/processors/build_output.py
@@ -274,5 +274,8 @@ class BuildOutputProcessor(Processor):
             r"^\s*Using\s+(cached|version)\b",
             r"^\s*Collecting\s+\S+",  # pip
             r"^\s*━",  # pip progress bar
+            r"^\s*(Resolution|Fetch|Link)\s+step\b",  # yarn berry v2+ step progress
+            r"^\s*Progress:\s+resolved\s+\d+",  # pnpm resolved/reused/downloaded stats
+            r"^\s*packages?\s+(are|is)\s+hard linked",  # pnpm content-addressable store
         ]
         return any(re.match(p, line) for p in patterns)

--- a/src/processors/build_output.py
+++ b/src/processors/build_output.py
@@ -274,7 +274,7 @@ class BuildOutputProcessor(Processor):
             r"^\s*Using\s+(cached|version)\b",
             r"^\s*Collecting\s+\S+",  # pip
             r"^\s*━",  # pip progress bar
-            r"^.*(Resolution|Fetch|Link)\s+step\b",  # yarn berry v2+ (prefixed with ➤ YN0000: ┌)
+            r"^\s*\u27a4?\s*YN\d+:.*\b(Resolution|Fetch|Link)\s+step\b",  # yarn berry v2+
             r"^\s*Progress:\s+resolved\s+\d+",  # pnpm resolved/reused/downloaded stats
             r"^\s*[Pp]ackages?\s+(are|is)\s+hard linked",  # pnpm content-addressable store
         ]

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -281,6 +281,25 @@ class TestBuildPrecision:
         assert "Build succeeded" in compressed
         assert "245 KB" in compressed or "gzip" in compressed
 
+    def test_errors_mentioning_step_keywords_preserved(self):
+        """Errors containing 'Resolution step' or 'Fetch step' must not be stripped."""
+        output = "\n".join(
+            [f"  Resolving dep-{i}" for i in range(50)]
+            + [
+                "error: Resolution step failed: ETIMEDOUT",
+                "  at NetworkManager.fetch (node_modules/yarn/lib/cli.js:123)",
+                "",
+                "error: Fetch step encountered a certificate error",
+                "  UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+            ]
+        )
+        compressed, _, was_compressed = self.engine.compress("yarn install", output)
+        assert was_compressed
+        assert "Resolution step failed" in compressed
+        assert "ETIMEDOUT" in compressed
+        assert "Fetch step encountered" in compressed
+        assert "UNABLE_TO_GET_ISSUER_CERT_LOCALLY" in compressed
+
 
 class TestLintPrecision:
     def setup_method(self):

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -529,6 +529,37 @@ class TestBuildOutputProcessor:
         assert "Collecting" not in result
         assert "Build succeeded" in result
 
+    def test_yarn_berry_step_progress_skipped(self):
+        """Yarn Berry (v2+) emits Resolution/Fetch/Link step lines as progress."""
+        output = "\n".join(
+            [
+                "Resolution step completed in 1.2s",
+                "Fetch step completed in 3.4s",
+                "Link step completed in 2.1s",
+                "Done in 6.7s",
+            ]
+        )
+        result = self.p.process("yarn install", output)
+        assert "Resolution step" not in result
+        assert "Fetch step" not in result
+        assert "Link step" not in result
+        assert "Build succeeded" in result
+
+    def test_pnpm_progress_lines_skipped(self):
+        """pnpm emits 'Progress: resolved N, ...' and hard link messages."""
+        output = "\n".join(
+            [
+                "Progress: resolved 150, reused 148, downloaded 2, added 150",
+                "Progress: resolved 200, reused 198, downloaded 2, added 200",
+                "packages are hard linked from the content-addressable store",
+                "Done in 4.2s",
+            ]
+        )
+        result = self.p.process("pnpm install", output)
+        assert "Progress:" not in result
+        assert "hard linked" not in result
+        assert "Build succeeded" in result
+
 
 class TestLintOutputProcessor:
     def setup_method(self):

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -530,13 +530,16 @@ class TestBuildOutputProcessor:
         assert "Build succeeded" in result
 
     def test_yarn_berry_step_progress_skipped(self):
-        """Yarn Berry (v2+) emits Resolution/Fetch/Link step lines as progress."""
+        """Yarn Berry (v2+) outputs step lines prefixed with ➤ YN0000: ┌/└."""
         output = "\n".join(
             [
-                "Resolution step completed in 1.2s",
-                "Fetch step completed in 3.4s",
-                "Link step completed in 2.1s",
-                "Done in 6.7s",
+                "\u27a4 YN0000: \u250c Resolution step",
+                "\u27a4 YN0000: \u2514 Completed in 0s 259ms",
+                "\u27a4 YN0000: \u250c Fetch step",
+                "\u27a4 YN0000: \u2514 Completed in 1s 263ms",
+                "\u27a4 YN0000: \u250c Link step",
+                "\u27a4 YN0000: \u2514 Completed in 0s 218ms",
+                "Done in 1.74s",
             ]
         )
         result = self.p.process("yarn install", output)
@@ -549,9 +552,9 @@ class TestBuildOutputProcessor:
         """pnpm emits 'Progress: resolved N, ...' and hard link messages."""
         output = "\n".join(
             [
+                "Packages are hard linked from the content-addressable store",
                 "Progress: resolved 150, reused 148, downloaded 2, added 150",
-                "Progress: resolved 200, reused 198, downloaded 2, added 200",
-                "packages are hard linked from the content-addressable store",
+                "Progress: resolved 200, reused 198, downloaded 2, added 200, done",
                 "Done in 4.2s",
             ]
         )


### PR DESCRIPTION
## Summary
- Add 3 missing progress line patterns to `BuildOutputProcessor._is_progress_line()`:
  - Yarn Berry (v2+) step progress lines, matching the real `➤ YN0000: ┌` prefix format
  - pnpm resolution progress counter (`Progress: resolved N, reused N, ...`)
  - pnpm content-addressable store messages (`Packages are hard linked`)
- Yarn berry regex is tightly anchored to the `YN` prefix to prevent false positives on error lines containing step keywords
- Add 2 unit tests and 1 precision test verifying:
  - Progress lines are correctly stripped
  - Error lines mentioning "Resolution step" or "Fetch step" are never stripped

## Precision guarantees respected
- Short outputs (<200 chars) still never modified (engine-level guard)
- Compression only applied if gain >10% (engine-level guard)
- All errors and stack traces fully preserved (verified by new precision test)
- Only noise removed: progress indicators from yarn berry and pnpm

## Test plan
- [x] `ruff check .` passes on changed files
- [x] `ruff format --check .` passes on changed files
- [x] All 220 tests pass (`python3 -m pytest tests/ -v`) — 217 original + 3 new
- [x] New precision test confirms error lines with step keywords survive compression