### PR TITLE
Fix platform.py → platforms.py filename references

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ extension/
 ├── src/                             # Shared source code
 │   ├── __init__.py
 │   ├── config.py                    # Configuration system
-│   ├── platform.py                  # Platform detection + I/O abstraction
+│   ├── platforms.py                 # Platform detection + I/O abstraction
 │   ├── engine.py                    # Compression engine (orchestrator)
 │   ├── hook_session.py              # SessionStart hook (stats, shared)
 │   ├── tracker.py                   # SQLite tracking

--- a/audit_compression.py
+++ b/audit_compression.py
@@ -763,7 +763,7 @@ audit(
 tree_lines = ["."]
 indent_chars = ["├── ", "│   ", "└── ", "    "]
 dirs_tree = {
-    "src": ["engine.py", "config.py", "tracker.py", "platform.py", "__init__.py"],
+    "src": ["engine.py", "config.py", "tracker.py", "platforms.py", "__init__.py"],
     "src/processors": [
         "git.py",
         "test_output.py",

--- a/installers/common.py
+++ b/installers/common.py
@@ -11,7 +11,7 @@ HOOK_MARKER = "token-saver"
 SHARED_FILES = [
     "src/__init__.py",
     "src/config.py",
-    "src/platform.py",
+    "src/platforms.py",
     "src/engine.py",
     "src/hook_session.py",
     "src/tracker.py",


### PR DESCRIPTION
The actual source file is src/platforms.py (plural) but three references used the singular form, causing a "Source file missing" warning during installation.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- What problem does this solve? Link to an issue if applicable: Fixes #123 -->

## How

<!-- Brief description of the approach taken. -->

## Checklist

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `python3 -m pytest tests/ -v` passes (all 207+ tests)
- [x] New code has tests (if applicable)
- [x] No secrets or credentials in the diff
