### PR TITLE
fix: support global options in hook patterns (git -C, kubectl -n, etc.)

### DIFF
--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -19,6 +19,16 @@ class TestHookPretool:
         assert is_compressible("git fetch --all")
         assert is_compressible("git reflog")
 
+    def test_git_global_options_compressible(self):
+        assert is_compressible("git -C /some/path status")
+        assert is_compressible("git -C /opt/homebrew log --oneline -20")
+        assert is_compressible("git --no-pager diff HEAD~1")
+        assert is_compressible("git -C /path --no-pager log")
+        assert is_compressible("git --no-pager -C /path status")
+        assert is_compressible("git -c core.pager=cat log --oneline")
+        assert is_compressible("git --git-dir=/path/.git status")
+        assert is_compressible("git --work-tree /path status")
+
     def test_test_commands_compressible(self):
         assert is_compressible("pytest tests/")
         assert is_compressible("python -m pytest")
@@ -89,6 +99,11 @@ class TestHookPretool:
         assert is_compressible("docker ps")
         assert is_compressible("docker logs container")
 
+    def test_docker_global_options_compressible(self):
+        assert is_compressible("docker --context remote ps")
+        assert is_compressible("docker -H tcp://host:2375 ps")
+        assert is_compressible("docker --host unix:///var/run/docker.sock images")
+
     def test_network_commands_compressible(self):
         assert is_compressible("curl https://example.com")
         assert is_compressible("curl -v https://api.example.com/data")
@@ -98,6 +113,15 @@ class TestHookPretool:
         assert is_compressible("kubectl get pods")
         assert is_compressible("kubectl describe pod my-pod")
         assert is_compressible("kubectl logs my-pod")
+
+    def test_kubectl_global_options_compressible(self):
+        assert is_compressible("kubectl -n kube-system get pods")
+        assert is_compressible("kubectl --namespace kube-system get pods")
+        assert is_compressible("kubectl --context prod get nodes")
+        assert is_compressible("kubectl -A get pods")
+        assert is_compressible("kubectl --all-namespaces get pods")
+        assert is_compressible("kubectl -n monitoring --context staging describe pod my-pod")
+        assert is_compressible("kubectl --kubeconfig /path/config get svc")
 
     def test_terraform_commands_compressible(self):
         assert is_compressible("terraform plan")


### PR DESCRIPTION
## Summary

- Hook patterns and `can_handle()` now correctly match commands with global options between the command name and subcommand
- Fixes `git -C <path>`, `kubectl -n <ns>`, `docker --context <ctx>` and similar forms that were silently skipped

## Problem

AI CLI tools like Claude Code use `git -C <path>` instead of `cd` + `git` to avoid changing the working directory. The hook regex `^git\s+(status|diff|log|...)` requires the subcommand to immediately follow `git`, so `git -C /path status` never matched — **most git commands in real usage went uncompressed**.

Same issue affected `kubectl -n <namespace> get pods` and `docker --context <ctx> ps`.

## Changes

**git** (`src/processors/git.py`):
- Allow `-C <path>`, `--no-pager`, `-c <key>=<val>`, `--git-dir`, `--work-tree` before the subcommand
- Refactored `process()` routing to use `_get_subcmd()` helper instead of per-method regex

**kubectl** (`src/processors/kubectl.py`):
- Allow `-n <ns>`, `--namespace`, `--context`, `--kubeconfig`, `-A`, `--all-namespaces` before the subcommand
- Same `_get_subcmd()` refactor

**docker** (`src/processors/docker.py`):
- Allow `--context`, `-H`, `--host` before the subcommand
- Same `_get_subcmd()` refactor

**Tests**:
- 24 new test cases across `test_hooks.py` and `test_processors.py`
- All 227 tests pass

## Test plan

- [x] `python3 -m pytest tests/ -v` — 227 passed
- [x] Manual verification: `git -C /opt/homebrew log --oneline` now matched by `is_compressible()`
- [x] Confirmed backward compatibility: all existing tests pass unchanged