### PR TITLE
fix: prevent self-delete during core install when src == dst

### DIFF
--- a/installers/common.py
+++ b/installers/common.py
@@ -73,6 +73,14 @@ def install_files(target_dir, file_list, use_symlink=False):
             print(f"  WARNING: Source file missing: {src}")
             continue
 
+        # Skip when source and destination resolve to the same file (core
+        # install running from ~/.token-saver/ would otherwise delete then
+        # copy).  realpath resolves symlinks; normcase handles Windows
+        # case-insensitive paths.
+        if os.path.normcase(os.path.realpath(src)) == os.path.normcase(os.path.realpath(dst)):
+            print(f"  OK   {rel_path}")
+            continue
+
         os.makedirs(os.path.dirname(dst), exist_ok=True)
 
         # Remove existing file/symlink before writing to avoid overwriting


### PR DESCRIPTION
When token-saver update runs from ~/.token-saver/ (tarball mode), install_core copies files from ~/.token-saver/ to ~/.token-saver/. The old code deleted dst before copying, but src and dst were the same file, causing FileNotFoundError on the subsequent copy.

Uses realpath (symlinks) + normcase (Windows case-insensitivity) for robust cross-platform same-file detection.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- What problem does this solve? Link to an issue if applicable: Fixes #123 -->

## How

<!-- Brief description of the approach taken. -->

## Checklist

- [ ] `ruff check .` passes
- [ ] `ruff format --check .` passes
- [ ] `python3 -m pytest tests/ -v` passes (all 207+ tests)
- [ ] New code has tests (if applicable)
- [ ] No secrets or credentials in the diff
