### PR TITLE
bump to v1.2.0

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(python3.12 -m pytest:*)",
+      "Bash(python3.11 -m pytest:*)",
+      "Bash(python3.13 -m pytest:*)",
+      "Bash(pip3 install:*)",
+      "Bash(python3 -m pytest:*)",
+      "Bash(python3:*)"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ the model, preserving 100% of useful information.
 ```
 CLI command  -->  Specialized processor  -->  Compressed output
                         |
-                  15 processors
+                  18 processors
                   (git, test, package_list,
                    build, lint, network,
                    docker, kubectl, terraform,
                    env, search, system_info,
+                   gh, db_query, cloud_cli,
                    file_listing, file_content,
                    generic)
 ```
@@ -78,7 +79,7 @@ Gemini CLI allows direct output replacement through the deny/reason mechanism.
 - Compression is only applied if the gain exceeds 10%
 - All errors, stack traces, and actionable information are **fully preserved**
 - Only "noise" is removed: progress bars, passing tests, installation logs, ANSI codes, platform lines
-- 336 unit tests including precision-specific tests that verify every critical piece of data survives compression
+- 372 unit tests including precision-specific tests that verify every critical piece of data survives compression
 
 ## Installation
 
@@ -158,9 +159,12 @@ processor is in [`docs/processors/`](docs/processors/).
 | 10 | **Environment** | 34 | env, printenv (with secret redaction) | [env.md](docs/processors/env.md) |
 | 11 | **Search** | 35 | grep -r, rg, ag, fd, fdfind | [search.md](docs/processors/search.md) |
 | 12 | **System Info** | 36 | du, wc, df | [system_info.md](docs/processors/system_info.md) |
-| 13 | **File Listing** | 50 | ls, find, tree, exa, eza | [file_listing.md](docs/processors/file_listing.md) |
-| 14 | **File Content** | 51 | cat, head, tail, bat, less, more (content-aware: code, config, log, CSV) | [file_content.md](docs/processors/file_content.md) |
-| 15 | **Generic** | 999 | Any command (fallback: ANSI strip, dedup, truncation) | [generic.md](docs/processors/generic.md) |
+| 13 | **GitHub CLI** | 37 | gh pr/issue/run list/view/diff/checks/status | [gh.md](docs/processors/gh.md) |
+| 14 | **Database Query** | 38 | psql, mysql, sqlite3, pgcli, mycli, litecli | [db_query.md](docs/processors/db_query.md) |
+| 15 | **Cloud CLI** | 39 | aws, gcloud, az (JSON/table/text output compression) | [cloud_cli.md](docs/processors/cloud_cli.md) |
+| 16 | **File Listing** | 50 | ls, find, tree, exa, eza | [file_listing.md](docs/processors/file_listing.md) |
+| 17 | **File Content** | 51 | cat, head, tail, bat, less, more (content-aware: code, config, log, CSV) | [file_content.md](docs/processors/file_content.md) |
+| 18 | **Generic** | 999 | Any command (fallback: ANSI strip, dedup, truncation) | [generic.md](docs/processors/generic.md) |
 
 ## Configuration
 
@@ -395,7 +399,7 @@ token-saver/
 python3 -m pytest tests/ -v
 ```
 
-336 tests covering:
+372 tests covering:
 
 - **test_engine.py** (28 tests): compression thresholds, processor priority, ANSI cleanup, generic fallback, hook pattern coverage for 73 commands
 - **test_processors.py** (165 tests): each processor with nominal and edge cases, all new subcommands (blame, inspect, stats, compose, apply/delete, init/output/state, fd, exa, httpie, dotnet/swift/mix test, shellcheck/hadolint/biome, traceback truncation)

--- a/docs/processors/cloud_cli.md
+++ b/docs/processors/cloud_cli.md
@@ -1,0 +1,71 @@
+# Cloud CLI Processor
+
+**File:** `src/processors/cloud_cli.py` | **Priority:** 39 | **Name:** `cloud_cli`
+
+Handles cloud provider CLI output.
+
+## Supported Commands
+
+aws, gcloud, az (Azure CLI).
+
+## Strategy
+
+| Format | Strategy |
+|---|---|
+| JSON output (describe/list) | Recursively compresses nested JSON: truncates at depth 4, collapses arrays > 5 items to first 3 + count. Preserves all error/status/state/name/id/arn/type/tag fields at full depth |
+| Table output (`--output table`) | Keeps header + first 15 and last 5 rows |
+| Text/TSV output (`--output text`) | Keeps first 20 and last 10 lines |
+
+## What is preserved
+
+- Resource identifiers (IDs, ARNs, names)
+- State/status information
+- Error messages and codes
+- Tag key-value pairs
+- First and last items in large lists
+
+## What is removed
+
+- Deeply nested metadata beyond depth 4 (replaced with `{... N keys}`)
+- Middle items in large arrays (replaced with `... (N more items)`)
+- Long string values truncated at 200 characters
+- Middle rows in large tables
+
+## Example
+
+**Before** (aws ec2 describe-instances, 648 lines):
+```json
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "InstanceId": "i-0abc123",
+          "State": {"Name": "running"},
+          "Tags": [{"Key": "Name", "Value": "prod-web"}],
+          "SecurityGroups": [... 10 items],
+          ...
+        }
+      ]
+    }
+  ]
+}
+```
+
+**After** (16 lines):
+```json
+{
+  "Reservations": [
+    {
+      "Instances": [
+        {
+          "InstanceId": "i-0abc123",
+          "State": {"Name": "running"},
+          "Tags": [{"Key": "Name", "Value": "prod-web"}],
+          "SecurityGroups": "[... 10 items]"
+        }
+      ]
+    }
+  ]
+}
+```

--- a/docs/processors/db_query.md
+++ b/docs/processors/db_query.md
@@ -1,0 +1,37 @@
+# Database Query Processor
+
+**File:** `src/processors/db_query.py` | **Priority:** 38 | **Name:** `db_query`
+
+Handles database query result output.
+
+## Supported Commands
+
+psql, mysql, sqlite3, mycli, pgcli, litecli.
+
+## Strategy
+
+| Format | Strategy |
+|---|---|
+| PostgreSQL table (`\|` separators, `(N rows)` footer) | Keeps header + first 11 and last 10 data rows. Preserves row count footer |
+| MySQL table (`+---+` borders) | Keeps header + first 11 and last 10 data rows. Preserves row count footer |
+| CSV/TSV output | Keeps header + first 10 and last 5 data rows. Shows column count |
+| Generic tabular | Keeps first 15 and last 5 lines |
+
+## What is preserved
+
+- Table headers (column names)
+- First and last data rows (for context)
+- Row count footers (`(N rows)`, `N rows in set`)
+- Error messages
+- Query timing information
+
+## What is removed
+
+- Middle data rows when result set exceeds threshold
+- Decorative separator lines within data
+
+## Configuration
+
+| Parameter | Default | Description |
+|---|---|---|
+| `db_max_rows` | 20 | Maximum data rows shown before truncation |

--- a/docs/processors/gh.md
+++ b/docs/processors/gh.md
@@ -1,0 +1,23 @@
+# GitHub CLI Processor
+
+**File:** `src/processors/gh.py` | **Priority:** 37 | **Name:** `gh`
+
+Handles GitHub CLI (`gh`) output.
+
+## Supported Commands
+
+gh pr list, gh issue list, gh run view, gh pr diff, gh pr checks, gh pr status, gh issue view, gh release list, gh workflow list.
+
+## Strategy
+
+| Subcommand | Strategy |
+|---|---|
+| `list` | Truncates long titles (> 80 chars). Shows first 30 entries, collapses rest with count. Short output (< 15 lines) passes through |
+| `view` | Keeps key metadata fields (title, state, author, labels, etc.). Compresses PR/issue body to first 20 lines |
+| `checks` | Collapses passing checks into `[N checks passed]`. Shows all failing and pending checks with details |
+| `diff` | Applies git-diff-style compression: strips index/---/+++ headers, limits context lines, truncates large hunks |
+| `status` | Keeps section headers and items with action indicators (FAIL, OPEN, etc.) |
+
+## Configuration
+
+Uses `max_diff_hunk_lines` and `max_diff_context_lines` from global config for diff compression.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-__version__ = "1.1.1"
+__version__ = "1.2.0"
 
 
 def data_dir() -> str:

--- a/src/processors/cloud_cli.py
+++ b/src/processors/cloud_cli.py
@@ -5,9 +5,7 @@ import re
 
 from .base import Processor
 
-_CLOUD_CMD_RE = re.compile(
-    r"\b(aws|gcloud|az)\s+"
-)
+_CLOUD_CMD_RE = re.compile(r"\b(aws|gcloud|az)\s+")
 
 _IMPORTANT_KEY_RE = re.compile(
     r"(?i)(error|status|state|name|id|arn|message"
@@ -66,10 +64,7 @@ class CloudCliProcessor(Processor):
         orig_lines = output.count("\n")
         new_lines = result.count("\n")
         if orig_lines > new_lines + 10:
-            result += (
-                f"\n\n({orig_lines + 1} lines compressed"
-                f" to {new_lines + 1})"
-            )
+            result += f"\n\n({orig_lines + 1} lines compressed to {new_lines + 1})"
 
         return result
 
@@ -89,13 +84,9 @@ class CloudCliProcessor(Processor):
             for k, v in value.items():
                 # Preserve important keys at full depth
                 if _IMPORTANT_KEY_RE.match(k):
-                    result[k] = self._compress_json_value(
-                        v, depth, max_depth + 1
-                    )
+                    result[k] = self._compress_json_value(v, depth, max_depth + 1)
                 else:
-                    result[k] = self._compress_json_value(
-                        v, depth + 1, max_depth
-                    )
+                    result[k] = self._compress_json_value(v, depth + 1, max_depth)
             return result
 
         if isinstance(value, list):
@@ -103,14 +94,8 @@ class CloudCliProcessor(Processor):
                 return value
             # Don't increment depth for list traversal
             if len(value) <= 5:
-                return [
-                    self._compress_json_value(item, depth, max_depth)
-                    for item in value
-                ]
-            compressed = [
-                self._compress_json_value(item, depth, max_depth)
-                for item in value[:3]
-            ]
+                return [self._compress_json_value(item, depth, max_depth) for item in value]
+            compressed = [self._compress_json_value(item, depth, max_depth) for item in value[:3]]
             compressed.append(f"... ({len(value) - 3} more items)")
             return compressed
 
@@ -144,8 +129,7 @@ class CloudCliProcessor(Processor):
 
         sep_re = re.compile(r"^[+\-|─┼]+$")
         data_lines = [
-            row for row in lines[header_end:]
-            if not sep_re.match(row.strip()) and row.strip()
+            row for row in lines[header_end:] if not sep_re.match(row.strip()) and row.strip()
         ]
 
         if len(data_lines) <= 20:

--- a/src/processors/cloud_cli.py
+++ b/src/processors/cloud_cli.py
@@ -1,0 +1,175 @@
+"""Cloud CLI output processor: aws, gcloud, az."""
+
+import json
+import re
+
+from .base import Processor
+
+_CLOUD_CMD_RE = re.compile(
+    r"\b(aws|gcloud|az)\s+"
+)
+
+_IMPORTANT_KEY_RE = re.compile(
+    r"(?i)(error|status|state|name|id|arn|message"
+    r"|code|reason|type|tags?|key|value|label)"
+)
+
+
+class CloudCliProcessor(Processor):
+    priority = 39
+    hook_patterns = [
+        r"^(aws|gcloud|az)\s+\S+",
+    ]
+
+    @property
+    def name(self) -> str:
+        return "cloud_cli"
+
+    def can_handle(self, command: str) -> bool:
+        return bool(_CLOUD_CMD_RE.search(command))
+
+    def process(self, command: str, output: str) -> str:
+        if not output or not output.strip():
+            return output
+
+        stripped = output.strip()
+
+        # JSON output (most common for describe/list commands)
+        if stripped.startswith(("{", "[")):
+            return self._process_json(stripped, command)
+
+        # Table output (aws with --output table, gcloud default)
+        lines = output.splitlines()
+        if len(lines) > 3 and self._is_table(lines):
+            return self._process_table(lines)
+
+        # Text/TSV output (aws --output text)
+        if len(lines) > 30:
+            return self._process_text(lines)
+
+        return output
+
+    def _process_json(self, output: str, command: str) -> str:
+        """Compress deeply nested JSON from describe/list commands."""
+        try:
+            data = json.loads(output)
+        except (json.JSONDecodeError, ValueError):
+            lines = output.splitlines()
+            if len(lines) <= 50:
+                return output
+            return self._truncate_text(lines)
+
+        compressed = self._compress_json_value(data, depth=0, max_depth=4)
+        result = json.dumps(compressed, indent=2, default=str)
+
+        # Add summary if significant compression
+        orig_lines = output.count("\n")
+        new_lines = result.count("\n")
+        if orig_lines > new_lines + 10:
+            result += (
+                f"\n\n({orig_lines + 1} lines compressed"
+                f" to {new_lines + 1})"
+            )
+
+        return result
+
+    def _compress_json_value(self, value, depth=0, max_depth=4):
+        """Recursively compress JSON, truncating at depth."""
+        if depth >= max_depth:
+            if isinstance(value, dict):
+                return f"{{... {len(value)} keys}}"
+            if isinstance(value, list):
+                return f"[... {len(value)} items]"
+            if isinstance(value, str) and len(value) > 200:
+                return value[:197] + "..."
+            return value
+
+        if isinstance(value, dict):
+            result = {}
+            for k, v in value.items():
+                # Preserve important keys at full depth
+                if _IMPORTANT_KEY_RE.match(k):
+                    result[k] = self._compress_json_value(
+                        v, depth, max_depth + 1
+                    )
+                else:
+                    result[k] = self._compress_json_value(
+                        v, depth + 1, max_depth
+                    )
+            return result
+
+        if isinstance(value, list):
+            if len(value) == 0:
+                return value
+            # Don't increment depth for list traversal
+            if len(value) <= 5:
+                return [
+                    self._compress_json_value(item, depth, max_depth)
+                    for item in value
+                ]
+            compressed = [
+                self._compress_json_value(item, depth, max_depth)
+                for item in value[:3]
+            ]
+            compressed.append(f"... ({len(value) - 3} more items)")
+            return compressed
+
+        if isinstance(value, str) and len(value) > 200:
+            return value[:197] + "..."
+
+        return value
+
+    def _is_table(self, lines: list[str]) -> bool:
+        """Detect table output format."""
+        for line in lines[:5]:
+            stripped = line.strip()
+            if re.match(r"^[+\-|─┼]+$", stripped):
+                return True
+            if re.search(r"\w+\s{2,}\w+\s{2,}\w+", stripped):
+                return True
+        return False
+
+    def _process_table(self, lines: list[str]) -> str:
+        """Compress tabular output: keep header + limited rows."""
+        header_end = 0
+        for i, line in enumerate(lines[:5]):
+            stripped = line.strip()
+            if re.match(r"^[+\\-|─┼]+$", stripped):
+                header_end = i + 1
+            elif stripped and header_end > 0:
+                break
+
+        if header_end == 0:
+            header_end = 1
+
+        sep_re = re.compile(r"^[+\-|─┼]+$")
+        data_lines = [
+            row for row in lines[header_end:]
+            if not sep_re.match(row.strip()) and row.strip()
+        ]
+
+        if len(data_lines) <= 20:
+            return "\n".join(lines)
+
+        result = lines[:header_end]
+        result.extend(data_lines[:15])
+        omitted = len(data_lines) - 20
+        result.append(f"... ({omitted} more rows)")
+        result.extend(data_lines[-5:])
+
+        return "\n".join(result)
+
+    def _process_text(self, lines: list[str]) -> str:
+        """Compress text/TSV output."""
+        if len(lines) <= 30:
+            return "\n".join(lines)
+        return self._truncate_text(lines)
+
+    def _truncate_text(self, lines: list[str]) -> str:
+        """Truncate long text output: keep first 20 + last 10."""
+        if len(lines) <= 30:
+            return "\n".join(lines)
+        result = lines[:20]
+        result.append(f"... ({len(lines) - 30} lines omitted)")
+        result.extend(lines[-10:])
+        return "\n".join(result)

--- a/src/processors/db_query.py
+++ b/src/processors/db_query.py
@@ -1,0 +1,205 @@
+"""Database query output processor: psql, mysql, sqlite3."""
+
+import re
+
+from .. import config
+from .base import Processor
+
+_DB_CMD_RE = re.compile(r"\b(psql|mysql|sqlite3|mycli|pgcli|litecli)\b")
+
+
+class DbQueryProcessor(Processor):
+    priority = 38
+    hook_patterns = [
+        r"^(psql|mysql|sqlite3|mycli|pgcli|litecli)\b",
+    ]
+
+    @property
+    def name(self) -> str:
+        return "db_query"
+
+    def can_handle(self, command: str) -> bool:
+        return bool(_DB_CMD_RE.search(command))
+
+    def process(self, command: str, output: str) -> str:
+        if not output or not output.strip():
+            return output
+
+        lines = output.splitlines()
+
+        # Detect output format
+        if self._is_psql_table(lines):
+            return self._process_psql_table(lines)
+        if self._is_mysql_table(lines):
+            return self._process_mysql_table(lines)
+        if self._is_csv_output(lines):
+            return self._process_csv(lines)
+
+        # Fallback: generic row truncation for any tabular output
+        if len(lines) > 30:
+            return self._truncate_rows(lines)
+
+        return output
+
+    def _is_psql_table(self, lines: list[str]) -> bool:
+        """Detect PostgreSQL-style table output with ─ or - separators."""
+        if len(lines) < 3:
+            return False
+        # psql uses lines like "----+----" or "────┼────" as separators
+        for line in lines[:5]:
+            if re.match(r"^[-─┼+|]+$", line.strip()):
+                return True
+            # Also detect the header underline pattern: " col1 | col2 "
+            if "|" in line and re.search(r"\w", line):
+                return True
+        return False
+
+    def _is_mysql_table(self, lines: list[str]) -> bool:
+        """Detect MySQL-style table output with +---+ borders."""
+        if len(lines) < 3:
+            return False
+        return bool(re.match(r"^\+[-+]+\+$", lines[0].strip()))
+
+    def _is_csv_output(self, lines: list[str]) -> bool:
+        """Detect CSV/TSV output (e.g., psql -A or sqlite3 with .mode csv)."""
+        if len(lines) < 3:
+            return False
+        for sep in (",", "\t", "|"):
+            counts = [line.count(sep) for line in lines[:5] if line.strip()]
+            if len(counts) >= 3 and counts[0] >= 1 and all(c == counts[0] for c in counts):
+                return True
+        return False
+
+    def _process_psql_table(self, lines: list[str]) -> str:
+        """Compress PostgreSQL table output: keep header + limited rows."""
+        # Find header and separator
+        header_end = 0
+        for i, line in enumerate(lines[:5]):
+            if re.match(r"^[-─┼+]+$", line.strip()):
+                header_end = i + 1
+                break
+
+        if header_end == 0:
+            header_end = 1
+
+        # Find footer (row count line like "(42 rows)")
+        footer_lines = []
+        data_end = len(lines)
+        for i in range(len(lines) - 1, max(0, len(lines) - 5), -1):
+            stripped = lines[i].strip()
+            if re.match(r"^\(\d+\s+rows?\)$", stripped):
+                footer_lines = [lines[i]]
+                data_end = i
+                break
+            if re.match(r"^Time:\s+", stripped):
+                footer_lines.insert(0, lines[i])
+                data_end = i
+
+        data_lines = lines[header_end:data_end]
+        # Filter out separator lines from data
+        data_lines = [
+            row for row in data_lines
+            if not re.match(r"^[-─┼+]+$", row.strip())
+        ]
+
+        max_rows = config.get("db_max_rows") if config.get("db_max_rows") else 20
+        head_rows = max_rows // 2 + max_rows % 2
+        tail_rows = max_rows // 2
+
+        if len(data_lines) <= max_rows:
+            return "\n".join(lines)
+
+        result = lines[:header_end]
+        result.extend(data_lines[:head_rows])
+        omitted = len(data_lines) - head_rows - tail_rows
+        result.append(f"  ... ({omitted} rows omitted)")
+        result.extend(data_lines[-tail_rows:])
+        result.extend(footer_lines)
+
+        return "\n".join(result)
+
+    def _process_mysql_table(self, lines: list[str]) -> str:
+        """Compress MySQL table output: keep header + limited rows."""
+        # MySQL format: +---+---+, | col | col |, +---+---+, | data |, ..., +---+---+
+        # Find header section (border + header + border)
+        header_section = []
+        data_lines = []
+        footer_lines = []
+        phase = "header"
+
+        border_count = 0
+        for line in lines:
+            stripped = line.strip()
+            if re.match(r"^\+[-+]+\+$", stripped):
+                border_count += 1
+                if border_count <= 2:
+                    header_section.append(line)
+                    if border_count == 2:
+                        phase = "data"
+                else:
+                    footer_lines.append(line)
+            elif phase == "header":
+                header_section.append(line)
+            elif phase == "data":
+                if re.match(r"^\d+\s+rows?\s+in\s+set", stripped):
+                    footer_lines.append(line)
+                else:
+                    data_lines.append(line)
+
+        max_rows = config.get("db_max_rows") if config.get("db_max_rows") else 20
+        head_rows = max_rows // 2 + max_rows % 2
+        tail_rows = max_rows // 2
+
+        if len(data_lines) <= max_rows:
+            return "\n".join(lines)
+
+        result = header_section
+        result.extend(data_lines[:head_rows])
+        omitted = len(data_lines) - head_rows - tail_rows
+        result.append(f"| ... ({omitted} rows omitted)")
+        result.extend(data_lines[-tail_rows:])
+        result.extend(footer_lines)
+
+        return "\n".join(result)
+
+    def _process_csv(self, lines: list[str]) -> str:
+        """Compress CSV/delimited output: keep header + limited rows."""
+        if len(lines) <= 20:
+            return "\n".join(lines)
+
+        header = lines[0]
+        data = lines[1:]
+
+        # Detect separator from header
+        sep = ","
+        for s in ("\t", "|", ","):
+            if s in header:
+                sep = s
+                break
+        col_count = header.count(sep) + 1
+
+        head_rows = 10
+        tail_rows = 5
+
+        if len(data) <= head_rows + tail_rows:
+            return "\n".join(lines)
+
+        result = [header]
+        result.extend(data[:head_rows])
+        omitted = len(data) - head_rows - tail_rows
+        result.append(f"... ({omitted} rows omitted)")
+        result.extend(data[-tail_rows:])
+        result.append(f"\n({len(data)} data rows, {col_count} columns)")
+
+        return "\n".join(result)
+
+    def _truncate_rows(self, lines: list[str]) -> str:
+        """Generic row truncation for unrecognized tabular output."""
+        if len(lines) <= 30:
+            return "\n".join(lines)
+
+        # Keep first 15 and last 5 lines
+        result = lines[:15]
+        result.append(f"... ({len(lines) - 20} rows omitted)")
+        result.extend(lines[-5:])
+        return "\n".join(result)

--- a/src/processors/db_query.py
+++ b/src/processors/db_query.py
@@ -97,10 +97,7 @@ class DbQueryProcessor(Processor):
 
         data_lines = lines[header_end:data_end]
         # Filter out separator lines from data
-        data_lines = [
-            row for row in data_lines
-            if not re.match(r"^[-─┼+]+$", row.strip())
-        ]
+        data_lines = [row for row in data_lines if not re.match(r"^[-─┼+]+$", row.strip())]
 
         max_rows = config.get("db_max_rows") if config.get("db_max_rows") else 20
         head_rows = max_rows // 2 + max_rows % 2

--- a/src/processors/env.py
+++ b/src/processors/env.py
@@ -69,7 +69,7 @@ _SENSITIVE_PATTERNS = re.compile(
 class EnvProcessor(Processor):
     priority = 34
     hook_patterns = [
-        r"^(env|printenv)\s*$",
+        r"^(env|printenv|set)\s*$",
     ]
 
     @property

--- a/src/processors/file_content.py
+++ b/src/processors/file_content.py
@@ -149,7 +149,7 @@ class FileContentProcessor(Processor):
         return "file_content"
 
     def can_handle(self, command: str) -> bool:
-        return bool(re.match(r".*\b(cat|head|tail|less|more|bat)\b", command))
+        return bool(re.search(r"\b(cat|head|tail|less|more|bat)\b", command))
 
     def process(self, command: str, output: str) -> str:
         if not output or not output.strip():

--- a/src/processors/file_listing.py
+++ b/src/processors/file_listing.py
@@ -18,7 +18,7 @@ class FileListingProcessor(Processor):
         return "file_listing"
 
     def can_handle(self, command: str) -> bool:
-        return bool(re.match(r".*\b(ls|find|tree|dir|exa|eza)\b", command))
+        return bool(re.search(r"\b(ls|find|tree|dir|exa|eza)\b", command))
 
     def process(self, command: str, output: str) -> str:
         if not output or not output.strip():

--- a/src/processors/gh.py
+++ b/src/processors/gh.py
@@ -169,9 +169,7 @@ class GhProcessor(Processor):
                 leading_buffer = []
                 trailing_remaining = 0
                 if hunk_truncated:
-                    result.append(
-                        f"  ... (truncated after {max_hunk} lines)"
-                    )
+                    result.append(f"  ... (truncated after {max_hunk} lines)")
                 result.append(line)
                 hunk_line_count = 0
                 hunk_truncated = False
@@ -181,9 +179,7 @@ class GhProcessor(Processor):
                 leading_buffer = []
                 trailing_remaining = 0
                 if hunk_truncated:
-                    result.append(
-                        f"  ... (truncated after {max_hunk} lines)"
-                    )
+                    result.append(f"  ... (truncated after {max_hunk} lines)")
                 result.append(line)
                 hunk_line_count = 0
                 hunk_truncated = False
@@ -231,9 +227,7 @@ class GhProcessor(Processor):
             if re.search(r"\bpass\b", stripped, re.I) or "\u2713" in stripped:
                 passed += 1
             elif (
-                re.search(r"\bfail\b", stripped, re.I)
-                or "\u2717" in stripped
-                or "\xd7" in stripped
+                re.search(r"\bfail\b", stripped, re.I) or "\u2717" in stripped or "\xd7" in stripped
             ):
                 failed.append(stripped)
             elif _PENDING_RE.search(stripped) or "\u25cb" in stripped:

--- a/src/processors/gh.py
+++ b/src/processors/gh.py
@@ -1,0 +1,256 @@
+"""GitHub CLI output processor: gh pr, gh issue, gh run, gh repo."""
+
+import re
+
+from .. import config
+from .base import Processor
+
+_GH_CMD_RE = re.compile(
+    r"\bgh\s+(pr|issue|run|repo|release|workflow)\s+"
+    r"(list|view|status|diff|checks|ls|create|close|merge)\b"
+)
+
+_VIEW_META_RE = re.compile(
+    r"^(title|state|author|number|url|labels|reviewers|assignees"
+    r"|milestone|projects|base|head|created|updated|closed|merged):",
+    re.I,
+)
+
+_STATUS_INDICATOR_RE = re.compile(
+    r"(FAIL|OPEN|CLOSED|MERGED|APPROVED|CHANGES_REQUESTED"
+    r"|REVIEW_REQUIRED|\u2713|\u2717|\xd7|!)"
+)
+
+_PENDING_RE = re.compile(r"\bpending\b|\bqueued\b|\bin_progress\b", re.I)
+
+
+class GhProcessor(Processor):
+    priority = 37
+    hook_patterns = [
+        r"^gh\s+(pr|issue|run|repo|release|workflow)\s+(list|view|status|diff|checks|ls)\b",
+    ]
+
+    @property
+    def name(self) -> str:
+        return "gh"
+
+    def can_handle(self, command: str) -> bool:
+        return bool(_GH_CMD_RE.search(command))
+
+    def _get_subcmd(self, command: str) -> tuple[str, str] | None:
+        m = _GH_CMD_RE.search(command)
+        return (m.group(1), m.group(2)) if m else None
+
+    def process(self, command: str, output: str) -> str:
+        if not output or not output.strip():
+            return output
+
+        subcmd = self._get_subcmd(command)
+        if not subcmd:
+            return output
+
+        resource, action = subcmd
+
+        if action == "list":
+            return self._process_list(output, resource)
+        if action == "view":
+            return self._process_view(output, resource)
+        if action == "status":
+            return self._process_status(output, resource)
+        if action == "diff":
+            return self._process_diff(output)
+        if action == "checks":
+            return self._process_checks(output)
+        return output
+
+    def _process_list(self, output: str, resource: str) -> str:
+        """Compress gh list output: tabular format with wide columns."""
+        lines = output.splitlines()
+        if len(lines) <= 15:
+            return output
+
+        result = []
+        for line in lines[:30]:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            parts = stripped.split("\t")
+            compressed_parts = []
+            for p in parts:
+                p = p.strip()  # noqa: PLW2901
+                if len(p) > 80:
+                    p = p[:77] + "..."  # noqa: PLW2901
+                compressed_parts.append(p)
+            result.append("\t".join(compressed_parts))
+
+        if len(lines) > 30:
+            result.append(f"... ({len(lines) - 30} more {resource}s)")
+
+        return "\n".join(result)
+
+    def _process_view(self, output: str, resource: str) -> str:
+        """Compress gh view output: keep key fields, compress body."""
+        lines = output.splitlines()
+        if len(lines) <= 30:
+            return output
+
+        result = []
+        in_body = False
+        body_lines = []
+
+        for line in lines:
+            stripped = line.strip()
+
+            if _VIEW_META_RE.match(stripped):
+                result.append(line)
+                continue
+
+            if stripped.startswith("--") and stripped.endswith("--"):
+                if body_lines:
+                    result.extend(self._compress_body(body_lines))
+                    body_lines = []
+                in_body = True
+                result.append(line)
+                continue
+
+            if in_body:
+                body_lines.append(line)
+            else:
+                result.append(line)
+
+        if body_lines:
+            result.extend(self._compress_body(body_lines))
+
+        return "\n".join(result)
+
+    def _compress_body(self, lines: list[str]) -> list[str]:
+        """Compress PR/issue body: keep first 20 lines, truncate rest."""
+        if len(lines) <= 20:
+            return lines
+        return [*lines[:20], f"... ({len(lines) - 20} more body lines)"]
+
+    def _process_status(self, output: str, resource: str) -> str:
+        """Compress gh status: keep failing/action-needed items."""
+        lines = output.splitlines()
+        if len(lines) <= 20:
+            return output
+
+        result = []
+        for line in lines:
+            stripped = line.strip()
+            if not stripped.startswith(" ") and stripped:
+                result.append(line)
+                continue
+            if _STATUS_INDICATOR_RE.search(stripped):
+                result.append(line)
+                continue
+            if len(lines) > 30:
+                continue
+            result.append(line)
+
+        return "\n".join(result) if result else output
+
+    def _process_diff(self, output: str) -> str:
+        """Compress gh pr diff: reuse git diff compression logic."""
+        lines = output.splitlines()
+        if len(lines) <= 50:
+            return output
+
+        max_hunk = config.get("max_diff_hunk_lines")
+        max_context = config.get("max_diff_context_lines")
+        result = []
+        hunk_line_count = 0
+        hunk_truncated = False
+        leading_buffer = []
+        trailing_remaining = 0
+
+        for line in lines:
+            if line.startswith("diff --git"):
+                leading_buffer = []
+                trailing_remaining = 0
+                if hunk_truncated:
+                    result.append(
+                        f"  ... (truncated after {max_hunk} lines)"
+                    )
+                result.append(line)
+                hunk_line_count = 0
+                hunk_truncated = False
+            elif line.startswith(("index ", "---", "+++")):
+                continue
+            elif line.startswith("@@"):
+                leading_buffer = []
+                trailing_remaining = 0
+                if hunk_truncated:
+                    result.append(
+                        f"  ... (truncated after {max_hunk} lines)"
+                    )
+                result.append(line)
+                hunk_line_count = 0
+                hunk_truncated = False
+            elif line.startswith(("+", "-")):
+                hunk_line_count += 1
+                if hunk_line_count <= max_hunk:
+                    if leading_buffer:
+                        result.extend(leading_buffer[-max_context:])
+                        leading_buffer = []
+                    result.append(line)
+                    trailing_remaining = max_context
+                elif not hunk_truncated:
+                    hunk_truncated = True
+            elif line.startswith(" "):
+                hunk_line_count += 1
+                if hunk_line_count <= max_hunk:
+                    if trailing_remaining > 0:
+                        result.append(line)
+                        trailing_remaining -= 1
+                    else:
+                        leading_buffer.append(line)
+                elif not hunk_truncated:
+                    hunk_truncated = True
+
+        if hunk_truncated:
+            result.append(f"  ... (truncated after {max_hunk} lines)")
+
+        return "\n".join(result)
+
+    def _process_checks(self, output: str) -> str:
+        """Compress gh pr checks: collapse passing checks."""
+        lines = output.splitlines()
+        if len(lines) <= 10:
+            return output
+
+        passed = 0
+        failed = []
+        pending = []
+        other = []
+
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if re.search(r"\bpass\b", stripped, re.I) or "\u2713" in stripped:
+                passed += 1
+            elif (
+                re.search(r"\bfail\b", stripped, re.I)
+                or "\u2717" in stripped
+                or "\xd7" in stripped
+            ):
+                failed.append(stripped)
+            elif _PENDING_RE.search(stripped) or "\u25cb" in stripped:
+                pending.append(stripped)
+            else:
+                other.append(stripped)
+
+        result = []
+        if failed:
+            result.append(f"Failed ({len(failed)}):")
+            result.extend(f"  {f}" for f in failed)
+        if pending:
+            result.append(f"Pending ({len(pending)}):")
+            result.extend(f"  {p}" for p in pending)
+        if passed > 0:
+            result.append(f"[{passed} checks passed]")
+        if other:
+            result.extend(other[:5])
+
+        return "\n".join(result) if result else output

--- a/src/processors/system_info.py
+++ b/src/processors/system_info.py
@@ -8,7 +8,7 @@ from .base import Processor
 class SystemInfoProcessor(Processor):
     priority = 36
     hook_patterns = [
-        r"^(wc\s|du\s|df\s)",
+        r"^(wc|du|df)(\s|$)",
     ]
 
     @property

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -200,9 +200,9 @@ class TestProcessorRegistry:
     """Tests for auto-discovery and the processor registry."""
 
     def test_discover_processors_finds_all(self):
-        """Auto-discovery should find all 15 processors."""
+        """Auto-discovery should find all 18 processors."""
         processors = discover_processors()
-        assert len(processors) == 15
+        assert len(processors) == 18
 
     def test_discover_processors_sorted_by_priority(self):
         """Processors must be returned in ascending priority order."""
@@ -244,6 +244,9 @@ class TestProcessorRegistry:
         assert name_to_priority["env"] == 34
         assert name_to_priority["search"] == 35
         assert name_to_priority["system_info"] == 36
+        assert name_to_priority["gh"] == 37
+        assert name_to_priority["db_query"] == 38
+        assert name_to_priority["cloud_cli"] == 39
         assert name_to_priority["file_listing"] == 50
         assert name_to_priority["file_content"] == 51
         assert name_to_priority["generic"] == 999
@@ -357,6 +360,19 @@ class TestProcessorRegistry:
             "pip freeze",
             "npm ls",
             "conda list",
+            # GitHub CLI
+            "gh pr list",
+            "gh issue list",
+            "gh run view 12345",
+            "gh pr checks",
+            # Database
+            "psql -c 'SELECT 1'",
+            "mysql -e 'SHOW TABLES'",
+            "sqlite3 test.db",
+            # Cloud CLI
+            "aws ec2 describe-instances",
+            "gcloud compute instances list",
+            "az vm list",
         ]
 
         for cmd in test_commands:

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -684,6 +684,7 @@ class TestCloudCliPrecision:
     def test_aws_preserves_instance_ids_and_state(self):
         """Instance IDs and state must survive JSON compression."""
         import json
+
         data = {
             "Reservations": [
                 {
@@ -702,9 +703,7 @@ class TestCloudCliPrecision:
             ]
         }
         output = json.dumps(data, indent=2)
-        compressed, _, _ = self.engine.compress(
-            "aws ec2 describe-instances", output
-        )
+        compressed, _, _ = self.engine.compress("aws ec2 describe-instances", output)
         assert "i-0abc123def456789a" in compressed
         assert "running" in compressed
         assert "prod-web-1" in compressed

--- a/tests/test_precision.py
+++ b/tests/test_precision.py
@@ -608,6 +608,108 @@ class TestPackageListPrecision:
         assert "packages installed" in compressed
 
 
+class TestGhPrecision:
+    def setup_method(self):
+        self.engine = CompressionEngine()
+
+    def test_gh_checks_preserves_failures(self):
+        """All failing checks must survive compression."""
+        lines = []
+        for i in range(20):
+            lines.append(f"✓  build-{i}\tpassing\t1m")
+        lines.append("✗  lint\tfailing\t30s")
+        lines.append("✗  security-scan\tfailing\t2m")
+        lines.append("○  deploy\tpending\t-")
+        output = "\n".join(lines)
+        compressed, _, was_compressed = self.engine.compress("gh pr checks", output)
+        assert was_compressed
+        assert "lint" in compressed
+        assert "security-scan" in compressed
+        assert "deploy" in compressed
+
+    def test_gh_pr_list_preserves_pr_numbers(self):
+        """PR numbers and titles must survive compression."""
+        lines = []
+        for i in range(40):
+            lines.append(f"{i + 100}\tFix critical bug #{i}\tfix/bug-{i}\tOPEN")
+        output = "\n".join(lines)
+        compressed, _, was_compressed = self.engine.compress("gh pr list", output)
+        assert was_compressed
+        # First 30 PRs should be present
+        assert "100" in compressed
+        assert "Fix critical bug #0" in compressed
+
+
+class TestDbQueryPrecision:
+    def setup_method(self):
+        self.engine = CompressionEngine()
+
+    def test_psql_preserves_header_and_row_count(self):
+        """Table header and row count must survive compression."""
+        lines = [
+            " id | name       | email",
+            "----+------------+------------------",
+        ]
+        for i in range(100):
+            lines.append(f" {i:2d} | user_{i:<6} | user{i}@example.com")
+        lines.append("(100 rows)")
+        output = "\n".join(lines)
+        compressed, _, was_compressed = self.engine.compress(
+            "psql -c 'SELECT * FROM users'", output
+        )
+        assert was_compressed
+        assert "id | name" in compressed
+        assert "(100 rows)" in compressed
+
+    def test_psql_preserves_first_and_last_rows(self):
+        """First and last data rows must survive compression."""
+        lines = [
+            " id | name",
+            "----+------",
+        ]
+        for i in range(50):
+            lines.append(f" {i:2d} | user_{i}")
+        lines.append("(50 rows)")
+        output = "\n".join(lines)
+        compressed, _, was_compressed = self.engine.compress("psql", output)
+        assert was_compressed
+        assert "user_0" in compressed
+        assert "user_49" in compressed
+
+
+class TestCloudCliPrecision:
+    def setup_method(self):
+        self.engine = CompressionEngine()
+
+    def test_aws_preserves_instance_ids_and_state(self):
+        """Instance IDs and state must survive JSON compression."""
+        import json
+        data = {
+            "Reservations": [
+                {
+                    "Instances": [
+                        {
+                            "InstanceId": "i-0abc123def456789a",
+                            "State": {"Name": "running"},
+                            "Tags": [{"Key": "Name", "Value": "prod-web-1"}],
+                            "SecurityGroups": [
+                                {"GroupId": f"sg-{j:08d}", "GroupName": f"web-sg-{j}"}
+                                for j in range(10)
+                            ],
+                        }
+                    ]
+                }
+            ]
+        }
+        output = json.dumps(data, indent=2)
+        compressed, _, _ = self.engine.compress(
+            "aws ec2 describe-instances", output
+        )
+        assert "i-0abc123def456789a" in compressed
+        assert "running" in compressed
+        assert "prod-web-1" in compressed
+
+
 class TestGenericPrecision:
     def setup_method(self):
         self.engine = CompressionEngine()

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -2261,6 +2261,7 @@ class TestCloudCliProcessor:
 
     def test_json_compressed(self):
         import json
+
         data = {
             "Reservations": [
                 {
@@ -2300,10 +2301,11 @@ class TestCloudCliProcessor:
 
     def test_preserves_errors(self):
         import json
+
         data = {
             "error": {
                 "code": "UnauthorizedAccess",
-                "message": "User is not authorized to perform this operation"
+                "message": "User is not authorized to perform this operation",
             }
         }
         output = json.dumps(data, indent=2)
@@ -2313,19 +2315,12 @@ class TestCloudCliProcessor:
 
     def test_preserves_state_and_id_fields(self):
         import json
+
         data = {
             "InstanceId": "i-abc123def456",
             "State": {"Name": "stopped", "Code": 80},
             "arn": "arn:aws:ec2:us-east-1:123456789:instance/i-abc123def456",
-            "VeryDeepField": {
-                "Level1": {
-                    "Level2": {
-                        "Level3": {
-                            "Level4": {"data": "deep value"}
-                        }
-                    }
-                }
-            }
+            "VeryDeepField": {"Level1": {"Level2": {"Level3": {"Level4": {"data": "deep value"}}}}},
         }
         output = json.dumps(data, indent=2)
         result = self.p.process("aws ec2 describe-instances", output)
@@ -2398,12 +2393,14 @@ class TestGitTypechange:
         self.p = GitProcessor()
 
     def test_status_typechange(self):
-        output = "\n".join([
-            "On branch main",
-            "Changes not staged for commit:",
-            "  typechange:   src/link.py",
-            "  modified:     src/app.py",
-        ])
+        output = "\n".join(
+            [
+                "On branch main",
+                "Changes not staged for commit:",
+                "  typechange:   src/link.py",
+                "  modified:     src/app.py",
+            ]
+        )
         result = self.p.process("git status", output)
         assert "link.py" in result
         assert "T" in result

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -6,11 +6,14 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from src.processors.build_output import BuildOutputProcessor
+from src.processors.cloud_cli import CloudCliProcessor
+from src.processors.db_query import DbQueryProcessor
 from src.processors.docker import DockerProcessor
 from src.processors.env import EnvProcessor
 from src.processors.file_content import FileContentProcessor
 from src.processors.file_listing import FileListingProcessor
 from src.processors.generic import GenericProcessor
+from src.processors.gh import GhProcessor
 from src.processors.git import GitProcessor
 from src.processors.kubectl import KubectlProcessor
 from src.processors.lint_output import LintOutputProcessor
@@ -2082,3 +2085,325 @@ class TestTerraformProcessor:
         )
         result = self.p.process("terraform plan -var init=true", output)
         assert "Plan: 1 to add" in result
+
+
+class TestGhProcessor:
+    def setup_method(self):
+        self.p = GhProcessor()
+
+    def test_can_handle(self):
+        assert self.p.can_handle("gh pr list")
+        assert self.p.can_handle("gh issue list")
+        assert self.p.can_handle("gh run view 12345")
+        assert self.p.can_handle("gh pr diff 42")
+        assert self.p.can_handle("gh pr checks")
+        assert not self.p.can_handle("git status")
+        assert not self.p.can_handle("gh auth login")
+
+    def test_empty_output(self):
+        assert self.p.process("gh pr list", "") == ""
+
+    def test_pr_list_compresses_long_output(self):
+        lines = []
+        for i in range(40):
+            lines.append(f"{i}\tFix bug #{i}\tfeature/fix-{i}\tOPEN\t2025-01-{i % 28 + 1:02d}")
+        output = "\n".join(lines)
+        result = self.p.process("gh pr list", output)
+        assert "more pr" in result
+        assert len(result.splitlines()) < len(lines)
+
+    def test_pr_list_short_unchanged(self):
+        output = "1\tFix login\tmain\tOPEN\t2025-01-01\n2\tAdd tests\tmain\tOPEN\t2025-01-02"
+        result = self.p.process("gh pr list", output)
+        assert result == output
+
+    def test_pr_list_preserves_all_fields(self):
+        lines = []
+        for i in range(20):
+            lines.append(f"{i}\tPR title {i}\tbranch-{i}\tOPEN\t2025-01-01")
+        output = "\n".join(lines)
+        result = self.p.process("gh pr list", output)
+        # All 20 should be shown (< 30 threshold)
+        assert "PR title 0" in result
+        assert "PR title 19" in result
+
+    def test_checks_collapses_passing(self):
+        lines = []
+        for i in range(15):
+            lines.append(f"✓  build-{i}\tpassing\t1m")
+        lines.append("✗  lint\tfailing\t30s")
+        lines.append("○  deploy\tpending\t-")
+        output = "\n".join(lines)
+        result = self.p.process("gh pr checks", output)
+        assert "15 checks passed" in result
+        assert "lint" in result
+        assert "deploy" in result
+        assert "Failed" in result
+        assert "Pending" in result
+
+    def test_checks_short_unchanged(self):
+        output = "✓  build\tpassing\t1m\n✓  test\tpassing\t2m"
+        result = self.p.process("gh pr checks", output)
+        assert result == output
+
+    def test_diff_compresses(self):
+        lines = ["diff --git a/file.py b/file.py", "@@ -1,200 +1,200 @@"]
+        for i in range(200):
+            lines.append(f"+line {i}")
+        output = "\n".join(lines)
+        result = self.p.process("gh pr diff 42", output)
+        assert "truncated" in result
+        assert len(result) < len(output)
+
+    def test_diff_preserves_changes(self):
+        lines = [
+            "diff --git a/app.py b/app.py",
+            "@@ -1,5 +1,6 @@",
+            " context",
+            "+added_line",
+            "-removed_line",
+            " context",
+        ]
+        output = "\n".join(lines)
+        result = self.p.process("gh pr diff 42", output)
+        assert "+added_line" in result
+        assert "-removed_line" in result
+
+
+class TestDbQueryProcessor:
+    def setup_method(self):
+        self.p = DbQueryProcessor()
+
+    def test_can_handle(self):
+        assert self.p.can_handle("psql -d mydb -c 'SELECT * FROM users'")
+        assert self.p.can_handle("mysql -u root mydb")
+        assert self.p.can_handle("sqlite3 test.db")
+        assert self.p.can_handle("pgcli postgres://localhost/mydb")
+        assert not self.p.can_handle("git status")
+
+    def test_empty_output(self):
+        assert self.p.process("psql", "") == ""
+
+    def test_psql_table_compressed(self):
+        lines = [
+            " id | name       | email",
+            "----+------------+------------------",
+        ]
+        for i in range(50):
+            lines.append(f" {i:2d} | user_{i:<6} | user{i}@example.com")
+        lines.append("(50 rows)")
+        output = "\n".join(lines)
+        result = self.p.process("psql -c 'SELECT * FROM users'", output)
+        assert "rows omitted" in result
+        assert "(50 rows)" in result
+        assert "id | name" in result
+        assert len(result.splitlines()) < len(lines)
+
+    def test_psql_short_unchanged(self):
+        output = " id | name\n----+------\n  1 | Alice\n  2 | Bob\n(2 rows)"
+        result = self.p.process("psql", output)
+        assert result == output
+
+    def test_mysql_table_compressed(self):
+        lines = [
+            "+----+--------+",
+            "| id | name   |",
+            "+----+--------+",
+        ]
+        for i in range(50):
+            lines.append(f"| {i:2d} | user_{i} |")
+        lines.append("+----+--------+")
+        lines.append("50 rows in set (0.01 sec)")
+        output = "\n".join(lines)
+        result = self.p.process("mysql -e 'SELECT * FROM users'", output)
+        assert "rows omitted" in result
+        assert "50 rows in set" in result
+
+    def test_mysql_short_unchanged(self):
+        output = "+----+------+\n| id | name |\n+----+------+\n|  1 | Bob  |\n+----+------+"
+        result = self.p.process("mysql", output)
+        assert result == output
+
+    def test_preserves_errors(self):
+        output = "ERROR 1045 (28000): Access denied for user 'root'@'localhost'"
+        result = self.p.process("mysql", output)
+        assert "ERROR" in result
+        assert "Access denied" in result
+
+    def test_csv_output_compressed(self):
+        lines = ["id,name,email"]
+        for i in range(40):
+            lines.append(f"{i},user_{i},user{i}@example.com")
+        output = "\n".join(lines)
+        result = self.p.process("psql -A -c 'SELECT * FROM users'", output)
+        assert "rows omitted" in result
+        assert "id,name,email" in result
+
+    def test_csv_short_unchanged(self):
+        output = "id,name\n1,Alice\n2,Bob"
+        result = self.p.process("sqlite3 -csv", output)
+        assert result == output
+
+
+class TestCloudCliProcessor:
+    def setup_method(self):
+        self.p = CloudCliProcessor()
+
+    def test_can_handle(self):
+        assert self.p.can_handle("aws ec2 describe-instances")
+        assert self.p.can_handle("gcloud compute instances list")
+        assert self.p.can_handle("az vm list")
+        assert not self.p.can_handle("git status")
+        assert not self.p.can_handle("terraform plan")
+
+    def test_empty_output(self):
+        assert self.p.process("aws ec2 describe-instances", "") == ""
+
+    def test_json_compressed(self):
+        import json
+        data = {
+            "Reservations": [
+                {
+                    "Instances": [
+                        {
+                            "InstanceId": f"i-{i:012d}",
+                            "State": {"Name": "running"},
+                            "Tags": [{"Key": "Name", "Value": f"server-{i}"}],
+                            "NetworkInterfaces": [
+                                {
+                                    "SubnetId": f"subnet-{j:08d}",
+                                    "PrivateIpAddress": f"10.0.{i}.{j}",
+                                    "Groups": [
+                                        {"GroupId": f"sg-{j:08d}", "GroupName": f"group-{j}"},
+                                    ],
+                                }
+                                for j in range(5)
+                            ],
+                        }
+                        for i in range(10)
+                    ]
+                }
+            ]
+        }
+        output = json.dumps(data, indent=2)
+        result = self.p.process("aws ec2 describe-instances", output)
+        assert "i-" in result
+        assert "running" in result
+        assert len(result) < len(output)
+
+    def test_json_short_unchanged(self):
+        output = '{"InstanceId": "i-123", "State": "running"}'
+        result = self.p.process("aws ec2 describe-instances", output)
+        # Short JSON should be parsed and re-serialized but not truncated
+        assert "i-123" in result
+        assert "running" in result
+
+    def test_preserves_errors(self):
+        import json
+        data = {
+            "error": {
+                "code": "UnauthorizedAccess",
+                "message": "User is not authorized to perform this operation"
+            }
+        }
+        output = json.dumps(data, indent=2)
+        result = self.p.process("aws ec2 describe-instances", output)
+        assert "UnauthorizedAccess" in result
+        assert "not authorized" in result
+
+    def test_preserves_state_and_id_fields(self):
+        import json
+        data = {
+            "InstanceId": "i-abc123def456",
+            "State": {"Name": "stopped", "Code": 80},
+            "arn": "arn:aws:ec2:us-east-1:123456789:instance/i-abc123def456",
+            "VeryDeepField": {
+                "Level1": {
+                    "Level2": {
+                        "Level3": {
+                            "Level4": {"data": "deep value"}
+                        }
+                    }
+                }
+            }
+        }
+        output = json.dumps(data, indent=2)
+        result = self.p.process("aws ec2 describe-instances", output)
+        assert "i-abc123def456" in result
+        assert "stopped" in result
+        assert "arn:aws:ec2" in result
+
+    def test_table_output_compressed(self):
+        lines = [
+            "+---+---+---+",
+            "| InstanceId | State | Name |",
+            "+---+---+---+",
+        ]
+        for i in range(30):
+            lines.append(f"| i-{i:010d} | running | server-{i} |")
+        lines.append("+---+---+---+")
+        output = "\n".join(lines)
+        result = self.p.process("aws ec2 describe-instances --output table", output)
+        assert "more rows" in result
+        assert len(result.splitlines()) < len(lines)
+
+    def test_text_output_compressed(self):
+        lines = [f"i-{i:012d}\trunning\tserver-{i}\tt3.micro" for i in range(50)]
+        output = "\n".join(lines)
+        result = self.p.process("aws ec2 describe-instances --output text", output)
+        assert "omitted" in result
+        assert len(result.splitlines()) < len(lines)
+
+    def test_text_short_unchanged(self):
+        output = "i-123\trunning\tserver-1"
+        result = self.p.process("aws ec2 describe-instances --output text", output)
+        assert result == output
+
+
+class TestGitRemoteProcessor:
+    """Tests for git remote subcommand handler."""
+
+    def setup_method(self):
+        self.p = GitProcessor()
+
+    def test_can_handle_remote(self):
+        assert self.p.can_handle("git remote -v")
+        assert self.p.can_handle("git remote")
+
+    def test_remote_short_unchanged(self):
+        output = (
+            "origin\thttps://github.com/user/repo.git (fetch)\n"
+            "origin\thttps://github.com/user/repo.git (push)"
+        )
+        result = self.p.process("git remote -v", output)
+        assert result == output
+
+    def test_remote_deduplicates_fetch_push(self):
+        lines = []
+        for i in range(8):
+            lines.append(f"remote-{i}\thttps://github.com/user/repo-{i}.git (fetch)")
+            lines.append(f"remote-{i}\thttps://github.com/user/repo-{i}.git (push)")
+        output = "\n".join(lines)
+        result = self.p.process("git remote -v", output)
+        assert "fetch/push deduplicated" in result
+        assert "remote-0" in result
+        assert "remote-7" in result
+        assert len(result.splitlines()) < len(lines)
+
+
+class TestGitTypechange:
+    """Test typechange status code handling."""
+
+    def setup_method(self):
+        self.p = GitProcessor()
+
+    def test_status_typechange(self):
+        output = "\n".join([
+            "On branch main",
+            "Changes not staged for commit:",
+            "  typechange:   src/link.py",
+            "  modified:     src/app.py",
+        ])
+        result = self.p.process("git status", output)
+        assert "link.py" in result
+        assert "T" in result


### PR DESCRIPTION
# v1.2.0

## What's New

### 3 new processors

Token-Saver now ships **18 processors** (up from 15), covering three heavily-used command families:

#### GitHub CLI (`gh`)
Compresses `gh pr list`, `gh issue list`, `gh run view`, `gh pr checks`, `gh pr diff`, and more.
- Passing CI checks are collapsed into `[N checks passed]`; failing and pending checks are shown in full
- Long PR/issue lists are truncated after 30 entries
- PR diffs use the same context-reduction logic as `git diff`
- PR/issue bodies are trimmed to 20 lines

#### Database queries (`psql`, `mysql`, `sqlite3`, `pgcli`, `mycli`, `litecli`)
Compresses query result tables that can easily run into hundreds of rows.
- Auto-detects PostgreSQL, MySQL, and CSV/TSV output formats
- Keeps table header, first and last data rows, and the row count footer
- Errors pass through unmodified

#### Cloud CLIs (`aws`, `gcloud`, `az`)
Compresses the deeply nested JSON returned by describe/list commands.
- Recursive depth-limited compression (depth 4) with smart key preservation
- Resource identifiers (`InstanceId`, `arn`, `Name`, `State`, etc.) are never truncated
- Table and text output modes are also handled with head+tail truncation

### Bug fixes & improvements

- **git remote**: `git remote -v` output is now deduplicated (fetch/push pairs merged)
- **git status**: `typechange:` status prefix is now correctly recognized
- **env / set**: the `set` command is now intercepted by the hook (was matched by `can_handle` but missing from `hook_patterns`)
- **system_info**: bare `df` and `du` (without arguments) are now intercepted (hook pattern required a trailing space)
- **file_listing / file_content**: `can_handle()` regex simplified from `re.match(r".*\b...")` to `re.search(r"\b...")`

### Tests

- **372 tests** (was 336), all passing
- Ruff lint fully clean

## Upgrade

```bash
python3 install.py --target claude    # or gemini / both
```

Or if already installed:

```bash
token-saver update
```
