### PR TITLE
fix(claude): respect session permissions in pretool hook

### DIFF
--- a/claude/hook_pretool.py
+++ b/claude/hook_pretool.py
@@ -215,10 +215,21 @@ def main():
     new_command = f"{session_prefix}{python} {shlex.quote(wrap_py)} {shlex.quote(command)}"
     _log.debug("Rewriting: %r -> %r (session=%s)", command, new_command, cc_session)
 
+    # Map Claude Code's session permission mode to our permission decision.
+    # This respects the user's Claude Code settings instead of always auto-allowing.
+    permission_map = {
+        "default": "ask",
+        "acceptEdits": "ask",
+        "plan": "deny",
+        "bypassPermissions": "allow",
+        "dontAsk": "allow",
+    }
+    permission_decision = permission_map.get(input_data.get("permission_mode", ""), "allow")
+
     result = {
         "hookSpecificOutput": {
             "hookEventName": "PreToolUse",
-            "permissionDecision": "allow",
+            "permissionDecision": permission_decision,
             "updatedInput": {"command": new_command},
         },
     }

--- a/src/platforms.py
+++ b/src/platforms.py
@@ -46,14 +46,9 @@ def get_tool_output(input_data: dict, platform: Platform) -> str | None:
     return None
 
 
-def format_pretool_rewrite(new_command: str, permission_decision: str = "allow") -> dict:
+def format_pretool_rewrite(new_command: str) -> dict:
     """Format a PreToolUse response that rewrites the command (Claude Code)."""
-    return {
-        "hookSpecificOutput": {
-            "permissionDecision": permission_decision,
-            "updatedInput": {"command": new_command},
-        }
-    }
+    return {"hookSpecificOutput": {"updatedInput": {"command": new_command}}}
 
 
 def format_aftertool_deny(compressed_output: str) -> dict:

--- a/src/platforms.py
+++ b/src/platforms.py
@@ -46,9 +46,14 @@ def get_tool_output(input_data: dict, platform: Platform) -> str | None:
     return None
 
 
-def format_pretool_rewrite(new_command: str) -> dict:
+def format_pretool_rewrite(new_command: str, permission_decision: str = "allow") -> dict:
     """Format a PreToolUse response that rewrites the command (Claude Code)."""
-    return {"hookSpecificOutput": {"updatedInput": {"command": new_command}}}
+    return {
+        "hookSpecificOutput": {
+            "permissionDecision": permission_decision,
+            "updatedInput": {"command": new_command},
+        }
+    }
 
 
 def format_aftertool_deny(compressed_output: str) -> dict:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -501,3 +501,55 @@ class TestChainedCommands:
     def test_three_segment_chain(self):
         assert is_compressible("cd /a && cd /b && git status")
         assert is_compressible("touch f && chmod 644 f && ls -la f")
+
+
+class TestPermissionMode:
+    """Tests for permission_mode → permissionDecision mapping."""
+
+    def _run_hook(self, input_data: dict) -> tuple[str, int]:
+        """Run hook_pretool.py with JSON input, return (stdout, exit_code)."""
+        import subprocess
+
+        hook_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "claude", "hook_pretool.py"
+        )
+        result = subprocess.run(  # noqa: S603, PLW1510
+            [sys.executable, hook_path],
+            input=json.dumps(input_data),
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.stdout, result.returncode
+
+    def _get_permission_decision(self, permission_mode=None):
+        """Run hook with a compressible command and return the permissionDecision."""
+        input_data = {"tool_name": "Bash", "tool_input": {"command": "git status"}}
+        if permission_mode is not None:
+            input_data["permission_mode"] = permission_mode
+        stdout, code = self._run_hook(input_data)
+        assert code == 0
+        assert stdout, "Expected rewritten output, got empty"
+        data = json.loads(stdout)
+        return data["hookSpecificOutput"]["permissionDecision"]
+
+    def test_default_permission_mode_returns_ask(self):
+        assert self._get_permission_decision("default") == "ask"
+
+    def test_accept_edits_returns_ask(self):
+        assert self._get_permission_decision("acceptEdits") == "ask"
+
+    def test_plan_mode_returns_deny(self):
+        assert self._get_permission_decision("plan") == "deny"
+
+    def test_bypass_permissions_returns_allow(self):
+        assert self._get_permission_decision("bypassPermissions") == "allow"
+
+    def test_dont_ask_returns_allow(self):
+        assert self._get_permission_decision("dontAsk") == "allow"
+
+    def test_missing_permission_mode_defaults_to_allow(self):
+        assert self._get_permission_decision() == "allow"
+
+    def test_unknown_permission_mode_defaults_to_allow(self):
+        assert self._get_permission_decision("something_new") == "allow"


### PR DESCRIPTION
## What

The goal is to respect the current session's permissions instead of always allowing the tool use for Claude Code.

## Why

If a user wants to deny all bash commands for a session, the pretool hook shouldn't bypass silently.

## How

Get the permission from the PreToolUse input args, and map them to the final "allow"/"ask"/"deny" decision.
NB: When the permission is "ask", the command shown to the user is the wrapped command. I couldn't find a way to show something different. But at the end of the day, the end-user should always know what command is being run if he's in "ask" mode.

## Checklist

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `python3 -m pytest tests/ -v` passes (all 485 tests)
- [x] New code has tests (if applicable)
- [x] No secrets or credentials in the diff
