### PR TITLE
Release v2.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,8 +11,8 @@
     {
       "name": "token-saver",
       "source": "./",
-      "description": "Automatically compresses verbose CLI output to save tokens. 21 specialized processors for git, docker, npm, terraform, kubectl, helm, ansible, and more.",
-      "version": "2.3.0",
+      "description": "Automatically compresses verbose CLI output to save tokens. 32 specialized processors for git, docker, npm, terraform, kubectl, helm, ansible, cargo, go, and more.",
+      "version": "2.4.0",
       "author": {
         "name": "ppgranger"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "token-saver",
-  "description": "Automatically compresses verbose CLI output (git, docker, npm, terraform, kubectl, etc.) to save tokens in Claude Code sessions. 21 specialized processors with content-aware compression.",
-  "version": "2.3.0",
+  "description": "Automatically compresses verbose CLI output (git, docker, npm, terraform, kubectl, etc.) to save tokens in Claude Code sessions. 32 specialized processors with content-aware compression.",
+  "version": "2.4.0",
   "author": {
     "name": "ppgranger",
     "url": "https://github.com/ppgranger"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 
 
 def data_dir() -> str:


### PR DESCRIPTION
## Summary
- Bump version to 2.4.0
- Update plugin metadata to reflect 32 processors (was 21)

## Why
The 2.3.0 cache was stale — version stayed at 2.3.0 for multiple processor additions, so plugin update flow never refreshed clients. Bumping to 2.4.0 forces cache refresh.