### PR TITLE
Release v2.4.1: token-saver update self-refresh

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "token-saver",
       "source": "./",
       "description": "Automatically compresses verbose CLI output to save tokens. 32 specialized processors for git, docker, npm, terraform, kubectl, helm, ansible, cargo, go, and more.",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "author": {
         "name": "ppgranger"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "token-saver",
   "description": "Automatically compresses verbose CLI output (git, docker, npm, terraform, kubectl, etc.) to save tokens in Claude Code sessions. 32 specialized processors with content-aware compression.",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": {
     "name": "ppgranger",
     "url": "https://github.com/ppgranger"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "token-saver"
-version = "2.3.0"
+version = "2.4.1"
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 
 
 def data_dir() -> str:

--- a/src/cli.py
+++ b/src/cli.py
@@ -42,51 +42,51 @@ def cmd_stats(args):
 
 
 def cmd_update(_args):
-    """Check for updates and apply if available."""
+    """Check for updates, then always refresh the local install.
+
+    Remote fetch is best-effort: if it fails or matches the local version,
+    we still re-run the installer so the Claude/Gemini plugin caches stay
+    in sync with the source files on disk.
+    """
     repo_dir = _repo_dir()
     print(f"token-saver v{__version__}")
 
     print("Checking for updates...")
+    latest = None
     try:
         latest = _fetch_latest_version(timeout=10)
     except urllib.error.HTTPError as e:
-        if e.code == 404:
-            print("No releases found on GitHub. Is the repository public with releases?")
-        else:
-            print(f"Failed to check for updates: HTTP {e.code}")
-        sys.exit(1)
+        print(f"Could not check remote: HTTP {e.code} (continuing with local refresh)")
     except Exception as e:
-        print(f"Failed to check for updates: {e}")
-        sys.exit(1)
+        print(f"Could not check remote: {e} (continuing with local refresh)")
 
-    try:
-        is_newer = _parse_version(latest) > _parse_version(__version__)
-    except (ValueError, TypeError):
-        print(f"Could not compare versions: local={__version__}, remote={latest}")
-        sys.exit(1)
+    is_newer = False
+    if latest is not None:
+        try:
+            is_newer = _parse_version(latest) > _parse_version(__version__)
+        except (ValueError, TypeError):
+            print(f"Could not compare versions: local={__version__}, remote={latest}")
 
-    if not is_newer:
-        print(f"Already up to date (v{__version__}).")
-        return
+    if is_newer:
+        print(f"Update available: v{__version__} -> v{latest}")
+        git_dir = os.path.join(repo_dir, ".git")
+        if os.path.isdir(git_dir):
+            _update_via_git(repo_dir, latest)
+        else:
+            _update_via_tarball(repo_dir, latest)
+    elif latest is not None:
+        print(f"Already on v{__version__} (no remote update).")
 
-    print(f"Update available: v{__version__} -> v{latest}")
-
-    git_dir = os.path.join(repo_dir, ".git")
-    if os.path.isdir(git_dir):
-        _update_via_git(repo_dir, latest)
-    else:
-        _update_via_tarball(repo_dir, latest)
-
-    # Re-run installer — detect which platforms are currently installed
     targets = _detect_installed_targets()
-    print(f"Re-running installer for: {targets}...")
+    print(f"Refreshing plugin install for: {targets}...")
     install_script = os.path.join(repo_dir, "install.py")
     subprocess.run(  # noqa: S603
         [sys.executable, install_script, "--target", targets],
         check=True,
     )
 
-    print(f"Update complete! Now running v{latest}.")
+    final_version = latest if is_newer else __version__
+    print(f"Done. Running v{final_version}.")
 
 
 def _detect_installed_targets():


### PR DESCRIPTION
## Summary
- \`token-saver update\` now always re-runs the installer, even when no remote update is available — equivalent to running \`/plugin marketplace update\` + \`/plugin update\` in Claude Code
- Remote fetch failures are now non-fatal (network blip won't abort a local refresh)
- Fixes \`pyproject.toml\` which still showed 2.3.0 after the v2.4.0 release

## Why
The 2.3.0 cache went stale because the installer was gated behind \`if not is_newer\`. Now \`update\` is fully idempotent and the cache stays in sync with the source on disk.

## Test plan
- [x] \`pytest tests/\` — 716 passed
- [x] Manual: \`token-saver update\` on already-current install → re-runs installer, refreshes cache
- [x] Manual: cache and marketplace dirs now both have all 32 processors