### PR TITLE
chore: bump version to 2.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "token-saver",
       "source": "./",
       "description": "Automatically compresses verbose CLI output to save tokens. 32 specialized processors for git, docker, npm, terraform, kubectl, helm, ansible, cargo, go, and more.",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "author": {
         "name": "ppgranger"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "token-saver",
   "description": "Automatically compresses verbose CLI output (git, docker, npm, terraform, kubectl, etc.) to save tokens in Claude Code sessions. 32 specialized processors with content-aware compression.",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "author": {
     "name": "ppgranger",
     "url": "https://github.com/ppgranger"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "token-saver"
-version = "2.5.0"
+version = "2.5.1"
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-__version__ = "2.4.2"
+__version__ = "2.5.1"
 
 
 def data_dir() -> str:


### PR DESCRIPTION
Fix v2.5.0 release that bumped pyproject.toml/plugin manifests but forgot src/__init__.py, leaving __version__ at 2.4.2. Result: every session triggered a spurious "Update available: v2.4.2 -> v2.5.0" notice because cli.py compared the stale __version__ to the GitHub tag.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- What problem does this solve? Link to an issue if applicable: Fixes #123 -->

## How

<!-- Brief description of the approach taken. -->

## Checklist

- [ ] `ruff check .` passes
- [ ] `ruff format --check .` passes
- [ ] `python3 -m pytest tests/ -v` passes (all 207+ tests)
- [ ] New code has tests (if applicable)
- [ ] No secrets or credentials in the diff
