### PR TITLE
chore: fix ruff CI failures (unused noqa + format drift)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "token-saver",
       "source": "./",
       "description": "Automatically compresses verbose CLI output to save tokens. 32 specialized processors for git, docker, npm, terraform, kubectl, helm, ansible, cargo, go, and more.",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "author": {
         "name": "ppgranger"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "token-saver",
   "description": "Automatically compresses verbose CLI output (git, docker, npm, terraform, kubectl, etc.) to save tokens in Claude Code sessions. 32 specialized processors with content-aware compression.",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "author": {
     "name": "ppgranger",
     "url": "https://github.com/ppgranger"

--- a/installers/common.py
+++ b/installers/common.py
@@ -30,6 +30,7 @@ def _processor_files():
         rels.append(f"src/processors/{name}")
     return rels
 
+
 SHARED_FILES = [
     "src/__init__.py",
     "src/chain_utils.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "token-saver"
-version = "2.6.1"
+version = "2.6.2"
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/scripts/wrap.py
+++ b/scripts/wrap.py
@@ -303,9 +303,7 @@ def main():
                 total_original,
                 total_compressed,
             )
-            core.record_saving(
-                command_str, proc_label, total_original, total_compressed, _PLATFORM
-            )
+            core.record_saving(command_str, proc_label, total_original, total_compressed, _PLATFORM)
         else:
             _log.debug("Chain not compressed: len=%d", total_original)
 
@@ -327,9 +325,7 @@ def main():
 
     if dry_run:
         diff_summary = summarize(output, result.compressed) if show_removed else None
-        _print_dry_run(
-            result.processor, len(output), len(result.compressed), output, diff_summary
-        )
+        _print_dry_run(result.processor, len(output), len(result.compressed), output, diff_summary)
         sys.exit(returncode)
 
     # Savings are attributed to the full command string (not just the primary)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-__version__ = "2.6.1"
+__version__ = "2.6.2"
 
 
 def data_dir() -> str:

--- a/src/cli.py
+++ b/src/cli.py
@@ -30,9 +30,7 @@ def _is_marketplace_managed(repo_dir: str) -> bool:
     marketplace, so ``token-saver update`` should defer to ``/plugin update``.
     """
     parts = [p.lower() for p in os.path.normpath(os.path.abspath(repo_dir)).split(os.sep)]
-    return any(
-        parts[i] == "plugins" and parts[i + 1] == "cache" for i in range(len(parts) - 1)
-    )
+    return any(parts[i] == "plugins" and parts[i + 1] == "cache" for i in range(len(parts) - 1))
 
 
 def _is_within_directory(directory: str, target: str) -> bool:
@@ -158,9 +156,7 @@ def _detect_installed_targets():
         claude_cache = os.path.join(
             h, ".claude", "plugins", "cache", "token-saver-marketplace", "token-saver"
         )
-        antigravity_dir = os.path.join(
-            h, ".gemini", "antigravity-cli", "plugins", "token-saver"
-        )
+        antigravity_dir = os.path.join(h, ".gemini", "antigravity-cli", "plugins", "token-saver")
 
     claude_installed = os.path.isdir(claude_old) or os.path.isdir(claude_cache)
     antigravity_installed = os.path.isdir(antigravity_dir)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -206,9 +206,7 @@ class TestMarketplaceDetection:
         from src.cli import _is_marketplace_managed
 
         # Pre-marketplace layout (~/.claude/plugins/token-saver) is self-updatable.
-        path = os.path.join(
-            os.path.expanduser("~"), ".claude", "plugins", "token-saver"
-        )
+        path = os.path.join(os.path.expanduser("~"), ".claude", "plugins", "token-saver")
         assert _is_marketplace_managed(path) is False
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -99,7 +99,7 @@ class TestRecording:
 
 class TestAntigravityHook:
     def _run_hook(self, payload):
-        return subprocess.run(  # noqa: S603, PLW1510
+        return subprocess.run(  # noqa: PLW1510
             [sys.executable, "antigravity/hook_aftertool.py"],
             input=json.dumps(payload),
             capture_output=True,


### PR DESCRIPTION
Remove unused S603 noqa directive in test_core.py and apply ruff formatting collapsed in newer ruff versions used by CI.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- What problem does this solve? Link to an issue if applicable: Fixes #123 -->

## How

<!-- Brief description of the approach taken. -->

## Checklist

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `python3 -m pytest tests/ -v` passes (all 207+ tests)
- [ ] New code has tests (if applicable)
- [ ] No secrets or credentials in the diff
