### PR TITLE
fix: install all top-level src modules by globbing instead of hardcoding

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "token-saver",
       "source": "./",
       "description": "Automatically compresses verbose CLI output to save tokens. 32 specialized processors for git, docker, npm, terraform, kubectl, helm, ansible, cargo, go, and more.",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "author": {
         "name": "ppgranger"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "token-saver",
   "description": "Automatically compresses verbose CLI output (git, docker, npm, terraform, kubectl, etc.) to save tokens in Claude Code sessions. 32 specialized processors with content-aware compression.",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "author": {
     "name": "ppgranger",
     "url": "https://github.com/ppgranger"

--- a/installers/common.py
+++ b/installers/common.py
@@ -31,17 +31,22 @@ def _processor_files():
     return rels
 
 
+def _src_files():
+    """All top-level src/*.py modules (plus the py.typed marker), discovered from disk.
+
+    Globbing instead of hardcoding keeps the install list from drifting out of
+    sync with the package.  A hardcoded list previously shipped installs missing
+    src/core.py and src/diffstat.py, which broke scripts/wrap.py at import time.
+    """
+    src_dir = os.path.join(EXTENSION_DIR, "src")
+    rels = [f"src/{os.path.basename(p)}" for p in sorted(glob.glob(os.path.join(src_dir, "*.py")))]
+    if os.path.exists(os.path.join(src_dir, "py.typed")):
+        rels.append("src/py.typed")
+    return rels
+
+
 SHARED_FILES = [
-    "src/__init__.py",
-    "src/chain_utils.py",
-    "src/config.py",
-    "src/platforms.py",
-    "src/engine.py",
-    "src/hook_session.py",
-    "src/tracker.py",
-    "src/stats.py",
-    "src/version_check.py",
-    "src/cli.py",
+    *_src_files(),
     *_processor_files(),
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "token-saver"
-version = "2.6.2"
+version = "2.6.3"
 requires-python = ">=3.10"
 
 [project.optional-dependencies]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-__version__ = "2.6.2"
+__version__ = "2.6.3"
 
 
 def data_dir() -> str:


### PR DESCRIPTION
The hardcoded SHARED_FILES list had drifted: src/core.py and src/diffstat.py (added with Antigravity support) and src/py.typed were never added, so the installer shipped a broken plugin that crashed scripts/wrap.py at import ("cannot import name 'core' from 'src'"), blocking every Bash command.

Glob src/*.py + py.typed, mirroring the existing _processor_files() helper, so the list can no longer drift out of sync with the package.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- What problem does this solve? Link to an issue if applicable: Fixes #123 -->

## How

<!-- Brief description of the approach taken. -->

## Checklist

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `python3 -m pytest tests/ -v` passes (all 207+ tests)
- [ ] New code has tests (if applicable)
- [x] No secrets or credentials in the diff
