### PR TITLE
fix(wrap): recognize chain markers glued to a segment without trailing newline

### DIFF
--- a/scripts/wrap.py
+++ b/scripts/wrap.py
@@ -95,8 +95,22 @@ def inject_markers(parts: list[tuple[str, str]], marker_prefix: str) -> str:
     return " ".join(pieces)
 
 
+def isolate_markers(output: str, marker_prefix: str) -> str:
+    """Ensure every marker starts on its own line.
+
+    `inject_markers` emits each marker with `echo`, but the preceding segment's
+    stdout is not guaranteed to end with a newline (`cat` on a file with no
+    final newline, `printf` without `\\n`, ...).  The marker then lands at the
+    end of that segment's last line, where the line-anchored patterns below
+    cannot see it: the marker leaks into the returned output and every later
+    segment collapses into segment 0.
+    """
+    return re.sub(r"(?<=[^\n])(?=" + re.escape(marker_prefix) + r"\d+)", "\n", output)
+
+
 def strip_markers(output: str, marker_prefix: str) -> str:
     """Remove marker lines from output (used for dry-run display)."""
+    output = isolate_markers(output, marker_prefix)
     pattern = re.compile(r"^" + re.escape(marker_prefix) + r"\d+\s*\n?", re.MULTILINE)
     return pattern.sub("", output)
 
@@ -109,6 +123,7 @@ def split_output_by_markers(output: str, marker_prefix: str) -> list[tuple[int, 
     Markers may be missing if an `&&` short-circuited mid-chain; the
     embedded indices keep the mapping correct.
     """
+    output = isolate_markers(output, marker_prefix)
     pattern = re.compile(r"^" + re.escape(marker_prefix) + r"(\d+)\s*$", re.MULTILINE)
     matches = list(pattern.finditer(output))
     if not matches:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1077,6 +1077,39 @@ class TestChainPerSegmentCompression:
         assert "segB" in result.stdout
         assert "__TS_MARK_" not in result.stdout
 
+    def test_split_output_marker_glued_to_previous_segment(self):
+        """A segment whose stdout has no trailing newline glues the next marker
+        onto its last line.  The marker must still split correctly.
+        """
+        wrap = self._import_wrap()
+        text = "out1M_1\nout2\nM_2\nout3"
+        chunks = wrap.split_output_by_markers(text, "M_")
+        assert chunks == [(0, "out1"), (1, "out2"), (2, "out3")]
+
+    def test_strip_markers_glued_to_previous_segment(self):
+        wrap = self._import_wrap()
+        text = "out1M_1\nout2"
+        assert wrap.strip_markers(text, "M_") == "out1\nout2"
+
+    def test_e2e_wrap_chain_no_marker_leak_without_trailing_newline(self):
+        """Real chain whose first segment emits no trailing newline."""
+        import subprocess
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        wrap_path = os.path.join(repo_root, "scripts", "wrap.py")
+        cmd = "printf segA; echo segB"
+        result = subprocess.run(  # noqa: S603, PLW1510
+            [sys.executable, wrap_path, cmd],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "segA" in result.stdout
+        assert "segB" in result.stdout
+        assert "__TS_MARK_" not in result.stdout
+
     def test_strip_markers_removes_lines(self):
         wrap = self._import_wrap()
         text = "out1\nM_1\nout2\nM_2\nout3"


### PR DESCRIPTION
Fixes #52

`inject_markers()` emits each chain marker with `echo`, but the preceding segment's stdout is not guaranteed to end with a newline. When it doesn't, the marker lands at the end of that segment's last line, where the line-anchored patterns in `strip_markers()` and `split_output_by_markers()` cannot match it. The marker leaks into the returned output and every later segment collapses into segment 0, so the wrong processor compresses it and per-segment savings are misattributed. The failure is silent.

Segments without a trailing newline are common in practice: `cat` on a flag/state file written by another tool, `printf` without `\n`, `git rev-parse --short HEAD > file`, editors with "insert final newline" disabled.

Before:

```
$ python3 scripts/wrap.py "printf segA; echo segB"
segA__TS_MARK_b5fac1a84616_1
segB
```

After:

```
$ python3 scripts/wrap.py "printf segA; echo segB"
segA
segB
```

## Approach

New `isolate_markers()` moves a glued marker onto its own line before matching, so both existing patterns work unchanged and the segment boundary the marker represents is preserved.

The `(?<=[^\n])` lookbehind requires a real non-newline character before the marker, so a marker that already starts a line — or sits at position 0 — is left untouched. No behaviour change for any case that works today.

Dropping the `^` anchor from the two patterns instead would strip the marker but merge the two segments onto one line (`segAsegB`), losing the boundary.

Note that the recent `inject_markers()` rewrite in #50 does not affect this: the marker's `echo` still runs immediately after the previous segment's stdout.

## Testing

Three regression tests added — two unit, one end-to-end through `wrap.py`:

- `test_split_output_marker_glued_to_previous_segment`
- `test_strip_markers_glued_to_previous_segment`
- `test_e2e_wrap_chain_no_marker_leak_without_trailing_newline`

All three fail against unpatched `wrap.py` and pass with the fix.

Full suite on this branch: `1295 passed, 12 skipped`. `ruff check` and `ruff format --check` clean.
