### PR TITLE
fix: close the residual bypasses behind issues #52 and #49

### DIFF
--- a/scripts/hook_pretool.py
+++ b/scripts/hook_pretool.py
@@ -154,7 +154,14 @@ EXCLUDED_PATTERNS = [
     *_STREAMING_EXCLUDED_PATTERNS,
 ]
 
-COMPILED_EXCLUDED = [re.compile(p) for p in EXCLUDED_PATTERNS]
+# re.MULTILINE so `^`/`$`-anchored patterns (sudo, vim, ssh, …) match at the
+# start/end of *every* line, not just the start/end of the whole string.
+# Defense in depth: has_unquoted_newline() is what actually stops a
+# multi-line command from reaching this point at all, but a multi-line
+# string that slips past it for any other reason (a future gap in the
+# quote-aware scanner, a new caller that skips that check) must still have
+# every line's dangerous prefix checked here, not just the first.
+COMPILED_EXCLUDED = [re.compile(p, re.MULTILINE) for p in EXCLUDED_PATTERNS]
 
 # Strip leading path prefix so '/usr/bin/git status' → 'git status',
 # './node_modules/.bin/jest' → 'jest', '.venv/bin/pip' → 'pip', etc.
@@ -202,7 +209,51 @@ _SEGMENT_EXCLUDED_PATTERNS = [
     *_STREAMING_EXCLUDED_PATTERNS,
 ]
 
-_COMPILED_SEGMENT_EXCLUDED = [re.compile(p) for p in _SEGMENT_EXCLUDED_PATTERNS]
+# Same defense-in-depth rationale as COMPILED_EXCLUDED above.
+_COMPILED_SEGMENT_EXCLUDED = [re.compile(p, re.MULTILINE) for p in _SEGMENT_EXCLUDED_PATTERNS]
+
+
+# Commands whose *output* is perfectly compressible, but which must never be
+# auto-approved on the user's behalf.  Wrapping a command means emitting
+# `permissionDecision: "allow"`, which per Claude Code's hook semantics runs
+# it with no confirmation prompt and without consulting the user's configured
+# allow/ask/deny rules.  That trade is fine for `git status`; it is not fine
+# for a command that force-pushes, tears down infrastructure, or deletes data
+# — the human-in-the-loop check is the whole point there, and saving a few
+# hundred tokens does not justify removing it.  Matching commands are left
+# entirely alone (no rewrite, no compression) so Claude Code applies its
+# normal permission flow.
+#
+# Deliberately narrow: each pattern targets the destructive *flag or
+# subcommand*, not the tool, so `git push` / `kubectl get` / `terraform plan`
+# stay compressible.  This list is not exhaustive and is not a security
+# boundary — it is a "don't silently bypass the user's own guard rails on the
+# obviously irreversible cases" list.
+_DESTRUCTIVE_PATTERNS = [
+    # force-push, but not the safer --force-with-lease
+    r"\bgit\s+push\b[^\n]*\s(?:--force\b(?!-with-lease)|-f\b)",
+    r"\bgit\s+reset\b[^\n]*\s--hard\b",
+    r"\bgit\s+clean\b[^\n]*\s-[a-zA-Z]*f",
+    r"\b(?:kubectl|oc)\b[^\n]*\bdelete\b",
+    r"\b(?:terraform|tofu)\s+(?:apply|destroy)\b",
+    r"\bdocker\b[^\n]*\b(?:system\s+prune|volume\s+rm|rmi)\b",
+    r"\b(?:docker|podman)\s+rm\b",
+    r"\brm\s+[^\n]*-[a-zA-Z]*[rR][a-zA-Z]*f|\brm\s+[^\n]*-[a-zA-Z]*f[a-zA-Z]*[rR]",  # rm -rf / -fr
+]
+
+_COMPILED_DESTRUCTIVE = [re.compile(p, re.MULTILINE) for p in _DESTRUCTIVE_PATTERNS]
+
+
+def is_destructive(command: str) -> bool:
+    """Return True if the command is irreversible enough that auto-approving
+    it would defeat the user's own permission rules.
+
+    Checked separately from :func:`is_compressible`: such a command may well
+    be compressible, but must not be rewritten, because rewriting is what
+    emits ``permissionDecision: "allow"``.
+    """
+    norm = _normalize_cmd(command)
+    return any(p.search(command) or p.search(norm) for p in _COMPILED_DESTRUCTIVE)
 
 
 def _ends_with_line_continuation(segment: str) -> bool:
@@ -466,6 +517,15 @@ def main():
 
     if not command or not is_compressible(command):
         _log.debug("Not compressible: %r", command[:200])
+        sys.exit(0)
+
+    if is_destructive(command):
+        # Compressible, but irreversible enough that we must not remove the
+        # user's normal permission check by auto-approving it — see
+        # is_destructive()'s docstring.  Emit nothing so Claude Code falls
+        # through to its own allow/ask/deny rules for this command exactly
+        # as if token-saver were not installed.
+        _log.debug("Destructive, declining to auto-approve: %r", command[:200])
         sys.exit(0)
 
     # Build path to wrap.py (same directory)

--- a/scripts/wrap.py
+++ b/scripts/wrap.py
@@ -28,6 +28,7 @@ import uuid
 # Ensure the extension root is importable (scripts/ -> plugin root)
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from scripts.hook_pretool import is_compressible
 from src import config, core
 from src.chain_utils import extract_primary_command, split_chain_with_ops
 from src.console import use_utf8_io
@@ -104,12 +105,17 @@ def inject_markers(parts: list[tuple[str, str]], marker_prefix: str) -> str:
 # matches: the marker token leaks into the model-facing text unstripped, and
 # worse, `split_output_by_markers` can't find the boundary at all, so the
 # entire remainder of the chain collapses into the wrong segment's chunk and
-# gets compressed (or dropped) by the wrong processor.  `(?:^|(?<=\S))`
-# accepts a true line start *or* being glued onto the end of prior non-
-# whitespace content, without weakening the match enough to fire inside
-# unrelated text — the prefix embeds a random 12-hex uuid, so a false
-# positive would require that exact token appearing by chance.
-_MARKER_LEFT_BOUNDARY = r"(?:^|(?<=\S))"
+# gets compressed (or dropped) by the wrong processor.  `(?:^|(?<=[^\n]))`
+# accepts a true line start *or* being glued onto the end of any prior
+# content on the same line.  An earlier version used `(?<=\S)` (non-
+# whitespace only), which still missed the marker whenever the glued-onto
+# content ended in a space, tab, or blank/indent-only line — `printf 'done '`
+# (trailing space) reproduced the exact same leak.  `[^\n]` covers every
+# same-line character and only excludes an actual newline, without weakening
+# the match enough to fire inside unrelated text — the prefix embeds a random
+# 12-hex uuid, so a false positive would require that exact token appearing
+# by chance.
+_MARKER_LEFT_BOUNDARY = r"(?:^|(?<=[^\n]))"
 
 
 def strip_markers(output: str, marker_prefix: str) -> str:
@@ -372,6 +378,34 @@ def main():
     # The command comes as a single quoted argument from hook_pretool.py
     command_str = args[0] if len(args) == 1 else " ".join(args)
     _log.debug("Executing command: %r", command_str)
+
+    # hook_pretool.py already classified this command as safe to wrap before
+    # rewriting it into `python3 wrap.py '<command>'` — but this script must
+    # not simply trust that verdict.  By the time we get here Claude Code has
+    # already been told `permissionDecision: allow`, so re-validating cannot
+    # retroactively stop execution of the command Claude Code decided to run
+    # — this script's whole job is to execute exactly that command.  What it
+    # *can* do is refuse to apply this script's own chain-rewrite assumptions
+    # (marker injection, per-segment splitting, per-segment compression) to a
+    # command the hook misjudged as chain-safe: those assumptions rely on
+    # every segment being an independent, safely-splittable statement, and a
+    # future gap in the hook's classifier — or a caller invoking this script
+    # directly, bypassing the hook entirely — must not be able to trick this
+    # rewrite into corrupting the command or misattributing one segment's
+    # output to another's processor.  On disagreement, fall back to running
+    # the original command string exactly as given, uncompressed — the same
+    # fail-safe already used below when the chain rewrite fails its shell
+    # syntax check.
+    if not is_compressible(command_str):
+        _log.warning(
+            "Re-validation rejected a command hook_pretool.py had classified "
+            "as compressible, running uncompressed: %r",
+            command_str,
+        )
+        stdout, stderr, returncode = _run_command(command_str, config.get("wrap_timeout"), False)
+        output = stdout + ("\n" + stderr if stderr else "")
+        print(_cap_output(output), end="")
+        sys.exit(returncode)
 
     timeout = config.get("wrap_timeout")
 

--- a/src/shell_syntax.py
+++ b/src/shell_syntax.py
@@ -32,12 +32,28 @@ def iter_unquoted(command: str) -> Iterator[tuple[int, str]]:
     for double quotes), the hook checks applied them to both (wrong for
     single).
 
+    A backslash *outside* any quoted region also escapes the character that
+    follows it — POSIX treats ``\\"`` and ``\\'`` outside quotes as literal
+    quote characters, not the start of a quoted region.  Both the escaping
+    backslash and the escaped character are consumed as a pair and never
+    yielded, so callers never see them as candidate operators: this closes
+    a bypass where a bare ``\\"`` (an ordinary, well-formed shell token) was
+    previously misread as an *opening* quote, causing the scanner to swallow
+    the rest of the string — including a smuggled ``&`` or newline — as if
+    it were quoted text.  A backslash immediately before a newline is POSIX's
+    own line-continuation syntax, so consuming the pair here has the added
+    effect of correctly *not* treating that newline as a statement separator,
+    without a separate check.
+
     An unterminated quote swallows the rest of the string: the safe direction,
     since we then find no operators and decline to wrap the command.
     """
     i, n = 0, len(command)
     while i < n:
         ch = command[i]
+        if ch == "\\" and i + 1 < n:
+            i += 2
+            continue
         if ch in _QUOTES:
             quote = ch
             escapes = quote == '"'

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from scripts.hook_pretool import explain_decision, is_compressible
+from scripts.hook_pretool import explain_decision, is_compressible, is_destructive
 
 
 class TestHookPretool:
@@ -335,6 +335,64 @@ class TestHookPretool:
         assert is_compressible("https POST https://api.example.com")
 
 
+class TestDestructiveCommandGuard:
+    """GitHub issue #49 sub-claim 4: never auto-approve a destructive
+    command just because its output happens to be compressible."""
+
+    def test_force_push_flagged(self):
+        assert is_destructive("git push --force origin main")
+        assert is_destructive("git push -f origin main")
+
+    def test_force_with_lease_not_flagged(self):
+        # The safer, non-destructive form of a force push must stay usable.
+        assert not is_destructive("git push --force-with-lease origin main")
+
+    def test_plain_push_not_flagged(self):
+        assert not is_destructive("git push origin main")
+
+    def test_git_reset_hard_flagged(self):
+        assert is_destructive("git reset --hard HEAD~1")
+
+    def test_git_clean_force_flagged(self):
+        assert is_destructive("git clean -fd")
+
+    def test_kubectl_delete_flagged(self):
+        assert is_destructive("kubectl delete pod foo")
+        assert is_destructive("oc delete deployment prod-api")
+
+    def test_kubectl_get_not_flagged(self):
+        assert not is_destructive("kubectl get pods")
+
+    def test_terraform_destroy_and_apply_flagged(self):
+        assert is_destructive("terraform destroy -auto-approve")
+        assert is_destructive("terraform apply -auto-approve")
+        assert is_destructive("tofu destroy")
+
+    def test_terraform_plan_not_flagged(self):
+        assert not is_destructive("terraform plan")
+
+    def test_docker_rm_and_prune_flagged(self):
+        assert is_destructive("docker rm mycontainer")
+        assert is_destructive("docker system prune -af")
+        assert is_destructive("docker rmi myimage")
+        assert is_destructive("podman rm mycontainer")
+
+    def test_docker_ps_not_flagged(self):
+        assert not is_destructive("docker ps")
+
+    def test_rm_rf_flagged(self):
+        assert is_destructive("rm -rf /tmp/foo")
+        assert is_destructive("rm -fr /tmp/foo")
+
+    def test_plain_rm_not_flagged(self):
+        assert not is_destructive("rm file.txt")
+
+    def test_benign_commands_not_flagged(self):
+        assert not is_destructive("git status")
+        assert not is_destructive("git log --oneline")
+        assert not is_destructive("docker logs mycontainer")
+
+
 class TestHookPretoolIntegration:
     """Test the full hook script behavior via subprocess."""
 
@@ -363,6 +421,30 @@ class TestHookPretoolIntegration:
         cmd = data["hookSpecificOutput"]["updatedInput"]["command"]
         assert "wrap.py" in cmd
         assert "git status" in cmd
+
+    def test_bash_force_push_not_auto_approved(self):
+        """A destructive command must produce no rewrite at all — Claude
+        Code then applies its own allow/ask/deny rules, exactly as if
+        token-saver were not installed."""
+        stdout, code = self._run_hook(
+            {"tool_name": "Bash", "tool_input": {"command": "git push --force origin main"}}
+        )
+        assert code == 0
+        assert stdout == ""
+
+    def test_bash_kubectl_delete_not_auto_approved(self):
+        stdout, code = self._run_hook(
+            {"tool_name": "Bash", "tool_input": {"command": "kubectl delete pod foo"}}
+        )
+        assert code == 0
+        assert stdout == ""
+
+    def test_bash_terraform_destroy_not_auto_approved(self):
+        stdout, code = self._run_hook(
+            {"tool_name": "Bash", "tool_input": {"command": "terraform destroy -auto-approve"}}
+        )
+        assert code == 0
+        assert stdout == ""
 
     def test_non_bash_tool_passthrough(self):
         stdout, code = self._run_hook({"tool_name": "Read", "tool_input": {"path": "/some/file"}})
@@ -532,6 +614,26 @@ class TestChainedCommands:
         """Heredocs break naive chain splitting; reject."""
         assert not is_compressible("cat <<EOF\nhello\nEOF")
         assert not is_compressible("git status && cat <<END\ndata\nEND")
+
+    def test_newline_smuggled_sudo_rejected(self):
+        """A hidden second line bypasses every per-segment safety check the
+        chain splitter would otherwise apply; reject the whole command."""
+        assert not is_compressible("git status\nsudo rm -rf /tmp/important")
+        assert not is_compressible("git status\nvim /etc/passwd")
+
+    def test_background_ampersand_smuggled_sudo_rejected(self):
+        assert not is_compressible("git status & sudo id")
+
+    def test_escaped_quote_prefix_no_longer_bypasses_newline_rejection(self):
+        """Regression for GitHub issue #49: a `\\"` outside any quoted region
+        used to be misread as an opening quote, swallowing the newline (and
+        everything after it) as if it were quoted text — hiding a smuggled
+        `sudo` from has_unquoted_newline entirely."""
+        assert not is_compressible('git status \\"\nsudo rm -rf /tmp/important')
+        assert not is_compressible('git log --grep=\\"fix\nsudo rm -rf /tmp/x')
+
+    def test_escaped_quote_prefix_no_longer_bypasses_background_rejection(self):
+        assert not is_compressible('git status \\" & touch /tmp/probe')
 
     def test_pipe_in_non_last_segment_rejected(self):
         assert not is_compressible("git status | grep foo && git diff")
@@ -1088,6 +1190,36 @@ class TestChainPerSegmentCompression:
         text = "doneM_1\nbody1"
         assert wrap.strip_markers(text, "M_") == "donebody1"
 
+    def test_split_output_marker_glued_after_trailing_space(self):
+        """A segment ending in a space (not just non-whitespace) also glues
+        the next marker onto the same line — `(?<=\\S)` alone missed this;
+        only `(?<=[^\\n])` catches every same-line character."""
+        wrap = self._import_wrap()
+        text = "full M_1\nBBB"
+        chunks = wrap.split_output_by_markers(text, "M_")
+        assert chunks == [(0, "full "), (1, "BBB")]
+
+    def test_split_output_marker_glued_after_trailing_tab(self):
+        wrap = self._import_wrap()
+        text = "full\tM_1\nBBB"
+        chunks = wrap.split_output_by_markers(text, "M_")
+        assert chunks == [(0, "full\t"), (1, "BBB")]
+
+    def test_split_output_marker_glued_after_blank_indent_line(self):
+        """A segment whose last line is pure indentation (no non-whitespace
+        content) still glues the marker — `\\S` requires a non-blank
+        character immediately to the left, which a blank/indent-only line
+        never has."""
+        wrap = self._import_wrap()
+        text = "A\n   M_1\nBBB"
+        chunks = wrap.split_output_by_markers(text, "M_")
+        assert chunks == [(0, "A\n   "), (1, "BBB")]
+
+    def test_strip_markers_glued_after_trailing_space(self):
+        wrap = self._import_wrap()
+        text = "full M_1\nBBB"
+        assert wrap.strip_markers(text, "M_") == "full BBB"
+
     def test_e2e_wrap_chain_compresses_per_segment(self):
         """Run wrap.py via subprocess on a real chain; verify both segments survive."""
         import subprocess
@@ -1127,6 +1259,61 @@ class TestChainPerSegmentCompression:
         assert result.returncode == 0, result.stderr
         assert "noNewlineHere" in result.stdout
         assert "segB" in result.stdout
+        assert "__TS_MARK_" not in result.stdout
+
+    def test_e2e_wrap_chain_survives_segment_ending_in_trailing_space(self):
+        """A segment ending in a trailing space (e.g. `printf 'v1.2.3 '` or a
+        file written without a final newline that happens to end in
+        whitespace) must not leak the raw marker into the output either."""
+        import subprocess
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        wrap_path = os.path.join(repo_root, "scripts", "wrap.py")
+        cmd = "printf 'trailingSpace ' && echo segB"
+        result = subprocess.run(  # noqa: S603, PLW1510
+            [sys.executable, wrap_path, cmd],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "trailingSpace" in result.stdout
+        assert "segB" in result.stdout
+        assert "__TS_MARK_" not in result.stdout
+
+    def test_wrap_reimports_is_compressible_for_revalidation(self):
+        """Regression for GitHub issue #49 sub-claim 3: wrap.py must not
+        blindly trust hook_pretool.py's classification of a chain as safe —
+        it re-runs is_compressible() itself before applying the chain
+        rewrite (marker injection, per-segment splitting)."""
+        wrap = self._import_wrap()
+        assert wrap.is_compressible is is_compressible
+
+    def test_e2e_wrap_skips_chain_rewrite_for_unsafe_chain(self):
+        """If a chain the hook would have classified as unsafe reaches
+        wrap.py directly (bypassing the hook, or via a future hook gap),
+        wrap.py's own revalidation must decline the chain-rewrite path
+        rather than injecting markers into a command it does not consider
+        safe to split."""
+        import subprocess
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        wrap_path = os.path.join(repo_root, "scripts", "wrap.py")
+        # `||` is always rejected by is_compressible, so this chain is
+        # unsafe by the same check hook_pretool.py already applies.
+        cmd = "echo segA || echo segB"
+        result = subprocess.run(  # noqa: S603, PLW1510
+            [sys.executable, wrap_path, cmd],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            timeout=10,
+        )
+        assert result.returncode == 0, result.stderr
+        # Ran uncompressed, exactly as bash would run it — no marker
+        # injection, no per-segment splitting.
+        assert "segA" in result.stdout
         assert "__TS_MARK_" not in result.stdout
 
     def test_strip_markers_removes_lines(self):

--- a/tests/test_shell_syntax.py
+++ b/tests/test_shell_syntax.py
@@ -1,0 +1,113 @@
+"""Tests for src/shell_syntax.py's quote-aware scanner and its consumers.
+
+Regression coverage for GitHub issue #49: an unquoted, backslash-escaped
+quote character (``\\"`` or ``\\'``) was misread by ``iter_unquoted`` as the
+*start* of a quoted region — POSIX shells treat it as an ordinary literal
+character instead — so the scanner swallowed the rest of the command string,
+blinding every safety check built on top of it (newline/background-operator
+smuggling, output redirection, dangerous constructs, chain splitting).
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.shell_syntax import (
+    has_output_redirection,
+    has_unquoted,
+    has_unquoted_background_operator,
+    has_unquoted_newline,
+    iter_unquoted,
+)
+
+
+def _visible(command: str) -> str:
+    """Concatenate every character iter_unquoted considers unquoted."""
+    return "".join(ch for _, ch in iter_unquoted(command))
+
+
+class TestIterUnquotedEscapes:
+    def test_escaped_double_quote_outside_quotes_is_not_an_opener(self):
+        # `\"` outside any quoted region is a literal quote character in
+        # POSIX, not the start of a double-quoted region.  The escaping
+        # backslash and the escaped `"` are consumed as a literal pair and
+        # not yielded (neither should be interpreted as a shell operator),
+        # but everything *after* the pair must still be visible — proving
+        # the scanner did not treat it as an unterminated quote opener.
+        s = 'echo a \\" b && sudo id'
+        assert _visible(s) == "echo a  b && sudo id"
+
+    def test_escaped_single_quote_outside_quotes_is_not_an_opener(self):
+        s = "echo a \\' b && sudo id"
+        assert _visible(s) == "echo a  b && sudo id"
+
+    def test_escaped_quote_does_not_swallow_following_newline(self):
+        s = 'git status \\"\nsudo rm -rf /tmp/important'
+        assert _visible(s) == "git status \nsudo rm -rf /tmp/important"
+
+    def test_escaped_quote_does_not_swallow_following_ampersand(self):
+        s = 'git status \\" & touch /tmp/probe'
+        assert _visible(s) == "git status  & touch /tmp/probe"
+
+    def test_real_double_quote_region_with_internal_escape_unchanged(self):
+        # Non-regression: `"a\"b"` is still a single quoted region — the
+        # escape *inside* double quotes is handled by the existing branch,
+        # untouched by this fix.
+        s = 'echo "a\\"b" && git status'
+        assert _visible(s) == "echo  && git status"
+
+    def test_real_single_quote_region_unchanged(self):
+        # Single quotes don't support escapes at all in POSIX — 'a\' ends
+        # at its second quote, with the backslash treated as a literal
+        # inside the region (not consumed specially).
+        s = "echo 'a\\' && git status"
+        assert _visible(s) == "echo  && git status"
+
+    def test_plain_backslash_space_is_still_consumed_as_a_pair(self):
+        # A backslash escaping an ordinary character (not a quote) is also
+        # consumed as a literal pair outside quotes, matching POSIX — the
+        # escaped space must not be mistaken for a word boundary.
+        s = "echo a\\ b && git status"
+        assert _visible(s) == "echo ab && git status"
+
+    def test_trailing_backslash_at_end_of_string_is_not_out_of_bounds(self):
+        # A lone trailing backslash has no following character to escape;
+        # iter_unquoted must not index past the end of the string.
+        s = "echo a\\"
+        assert _visible(s) == s
+
+
+class TestNewlineSmugglingClosed:
+    def test_bare_newline_still_rejected(self):
+        assert has_unquoted_newline("git status\nsudo rm -rf /tmp/x") is True
+
+    def test_escaped_quote_prefix_no_longer_bypasses_newline_check(self):
+        assert has_unquoted_newline('git status \\"\nsudo rm -rf /tmp/important') is True
+
+    def test_escaped_quote_prefix_with_grep_style_payload(self):
+        assert has_unquoted_newline('git log --grep=\\"fix\nsudo rm -rf /tmp/x') is True
+
+    def test_line_continuation_still_not_flagged(self):
+        # A backslash directly before the newline is a genuine POSIX line
+        # continuation, not a statement separator.
+        assert has_unquoted_newline("echo a \\\n&& git status") is False
+
+
+class TestBackgroundOperatorSmugglingClosed:
+    def test_bare_ampersand_still_rejected(self):
+        assert has_unquoted_background_operator("git status & touch /tmp/probe") is True
+
+    def test_escaped_quote_prefix_no_longer_bypasses_background_check(self):
+        assert has_unquoted_background_operator('git status \\" & touch /tmp/probe') is True
+
+    def test_double_ampersand_still_not_flagged(self):
+        assert has_unquoted_background_operator("git status && echo done") is False
+
+
+class TestOutputRedirectionAndDangerousConstructs:
+    def test_escaped_quote_prefix_no_longer_bypasses_redirection_check(self):
+        assert has_output_redirection('git status \\" > /etc/passwd') is True
+
+    def test_escaped_quote_prefix_no_longer_bypasses_construct_check(self):
+        assert has_unquoted('git status \\" $(id)', ("$(", "`", "<<")) is True


### PR DESCRIPTION
e28d083 patched the literal PoC strings from both issues but not the underlying bug class. Both were still exploitable with a one-character variation on the original reports.

#52: _MARKER_LEFT_BOUNDARY in wrap.py used (?<=\S), which still glued the next chain marker onto a segment ending in whitespace (trailing space, tab, or a blank/indent-only line), leaking the raw marker into output and collapsing segment attribution exactly as originally reported. Changed to (?<=[^\n]) to cover every same-line character.

#49: iter_unquoted (src/shell_syntax.py) only honored backslash escapes inside double-quoted regions. An unquoted " or \' — an ordinary, well-formed shell token — was misread as opening a quoted region that never closes, so the scanner swallowed everything after it, including a smuggled newline or &. This blinded has_unquoted_newline, has_unquoted_background_operator, has_output_redirection, and the dangerous-construct check simultaneously, since they all share this scanner. Fixed at the source: a backslash outside quotes is now consumed as a literal escape pair before quote detection.

Also closes the issue's three remaining sub-claims:
- re.MULTILINE added to both exclusion pattern lists (defense in depth)
- wrap.py now re-validates is_compressible() itself before applying its chain-rewrite, instead of trusting the hook's verdict unconditionally
- a new is_destructive() check withholds permissionDecision: allow for irreversible commands (force-push, git reset --hard, kubectl delete, terraform apply/destroy, docker rm/rmi/system prune, rm -rf), so they fall through to Claude Code's normal permission flow instead of being auto-approved

New tests/test_shell_syntax.py covers iter_unquoted and its consumers directly. tests/test_hooks.py gains regression coverage for the marker boundary, the classifier bypass, wrap.py's re-validation, and is_destructive(). Full suite: 1364 passed, 0 failed.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- What problem does this solve? Link to an issue if applicable: Fixes #123 -->

## How

<!-- Brief description of the approach taken. -->

## Checklist

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `python3 -m pytest tests/ -v` passes (all 207+ tests)
- [x] New code has tests (if applicable)
- [x] No secrets or credentials in the diff
