### PR TITLE
GEO: fix processor count drift + scaffold GitHub Pages

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "token-saver",
       "source": "./",
-      "description": "Automatically compresses verbose CLI output to save tokens. 32 specialized processors for git, docker, npm, terraform, kubectl, helm, ansible, cargo, go, and more.",
+      "description": "Automatically compresses verbose CLI output to save tokens. 36 specialized processors for git, docker, npm, terraform, kubectl, helm, ansible, cargo, go, and more.",
       "version": "2.7.1",
       "author": {
         "name": "ppgranger"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "token-saver",
-  "description": "Automatically compresses verbose CLI output (git, docker, npm, terraform, kubectl, etc.) to save tokens in Claude Code sessions. 32 specialized processors with content-aware compression.",
+  "description": "Automatically compresses verbose CLI output (git, docker, npm, terraform, kubectl, etc.) to save tokens in Claude Code sessions. 36 specialized processors with content-aware compression.",
   "version": "2.7.1",
   "author": {
     "name": "ppgranger",

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,34 @@
+theme: minima
+
+title: Token-Saver
+description: >-
+  Content-aware output compression for AI coding assistants. 36 specialized
+  processors compress verbose CLI output (git, pytest, npm, terraform,
+  kubectl, docker, and more) deterministically, saving 60-99% of tokens
+  without losing errors, diffs, or stack traces.
+url: "https://ppgranger.github.io"
+baseurl: "/token-saver"
+
+github_username: ppgranger
+repository: ppgranger/token-saver
+
+# Every page in docs/ sets its own front matter (title, description,
+# permalink) — see docs/processors/*.md for the pattern. Pages without
+# front matter are skipped by Jekyll's default collections, so nothing here
+# needs an explicit include/exclude list for the .md sources.
+
+minima:
+  skin: auto
+  social_links:
+    github: ppgranger/token-saver
+
+# Keep the build to the well-known-safe plugin whitelist GitHub Pages runs
+# without a custom Actions workflow. Anything outside this list forces a
+# switch to build-via-Actions, which is unnecessary for a static docs site.
+plugins:
+  - jekyll-relative-links
+
+markdown: kramdown
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge

--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,0 +1,57 @@
+<!--
+  minima's own `head.html` includes this file if present — this is the
+  theme's sanctioned extension point for <head> additions, so we don't have
+  to fork the whole default layout just to inject a meta description and
+  JSON-LD. Keeping it here means theme/gem updates never conflict with this
+  file.
+-->
+
+{% if page.description %}
+<meta name="description" content="{{ page.description | strip_html | strip_newlines | escape }}">
+{% endif %}
+
+{% if page.url == "/" %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "@id": "https://github.com/ppgranger/token-saver",
+  "name": "Token-Saver",
+  "description": "{{ site.description | strip_html | strip_newlines | escape }}",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "Windows, macOS, Linux",
+  "softwareVersion": "2.7.1",
+  "license": "https://github.com/ppgranger/token-saver/blob/main/LICENSE",
+  "codeRepository": "https://github.com/ppgranger/token-saver",
+  "url": "{{ site.url }}{{ site.baseurl }}/",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "author": {
+    "@type": "Person",
+    "name": "ppgranger",
+    "url": "https://github.com/ppgranger"
+  }
+}
+</script>
+{% elsif page.url contains "/processors/" or page.url == "/benchmarks/" or page.url == "/comparison/" %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TechArticle",
+  "headline": "{{ page.title | strip_html | strip_newlines | escape }}",
+  "description": "{{ page.description | strip_html | strip_newlines | escape }}",
+  "url": "{{ site.url }}{{ page.url | relative_url }}",
+  "isPartOf": {
+    "@id": "https://github.com/ppgranger/token-saver"
+  },
+  "author": {
+    "@type": "Person",
+    "name": "ppgranger",
+    "url": "https://github.com/ppgranger"
+  }
+}
+</script>
+{% endif %}

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,97 @@
+---
+title: Benchmarks
+description: 22 measured compression scenarios for Token-Saver, sorted by ratio, gated by CI so they cannot regress silently.
+permalink: /benchmarks/
+---
+
+# Token-Saver Compression Benchmarks
+
+Version: **2.7.1** · Baselines last updated: **2026-08-02** · Source: [`tests/compression_baselines.json`](https://github.com/ppgranger/token-saver/blob/main/tests/compression_baselines.json)
+
+These are not marketing estimates. Every row below is a fixed baseline
+checked into the repository and enforced by
+[`tests/test_compression_ratchet.py`](https://github.com/ppgranger/token-saver/blob/main/tests/test_compression_ratchet.py):
+CI fails if a code change makes any scenario compress worse than its recorded
+ratio (within a 2 percentage-point tolerance for incidental drift). The
+numbers can only go up, or a PR has to explicitly justify why one went down.
+
+## Methodology
+
+1. [`scripts/audit_compression.py`](https://github.com/ppgranger/token-saver/blob/main/scripts/audit_compression.py)
+   defines each scenario as a realistic `(command, output)` pair — e.g. a
+   `pytest` run with 500 tests and 2 failures, built from real-world output
+   shapes, not cherry-picked snippets.
+2. Each scenario is run through the real `CompressionEngine`
+   (`src/engine.py`), the same code path a live Claude Code or Antigravity
+   CLI session uses — no mocking, no separate "demo" implementation.
+3. The ratio is computed in **tokens**, not bytes or lines, using the same
+   `chars_per_token` estimate the engine uses internally, so the reported
+   percentage matches what actually leaves the context window.
+4. Baselines are regenerated only deliberately, by re-running the audit
+   script and committing the new JSON — never silently.
+
+Reproduce any row yourself:
+
+```bash
+git clone https://github.com/ppgranger/token-saver.git && cd token-saver
+python3 scripts/audit_compression.py            # full report, all scenarios
+python3 scripts/audit_compression.py --json      # machine-readable ratios
+python3 -m pytest tests/test_compression_ratchet.py -v
+```
+
+Or benchmark your own command instead of a fixed scenario:
+
+```bash
+python3 bin/token-saver benchmark 'git log --oneline -50'
+```
+
+## Results
+
+| Scenario | Processor | Compression ratio | Compressed? |
+|---|---|---|---|
+| `curl download (100 progress lines)` | network | 100.0% | Yes |
+| `npm install (220 packages)` | build | 99.9% | Yes |
+| `cargo build (120 crates)` | cargo | 97.8% | Yes |
+| `pytest (200 passed, 30 warnings, 0 failures)` | test | 97.7% | Yes |
+| `git diff --stat (25 files)` | git | 96.0% | Yes |
+| `pytest (500 passed, 2 failed)` | test | 95.4% | Yes |
+| `pip install -r requirements.txt (30 packages)` | python_install | 95.1% | Yes |
+| `jest (50 suites, all passing)` | test | 94.4% | Yes |
+| `tree (350+ lines)` | file_listing | 92.6% | Yes |
+| `eslint (55 violations, 2 rules)` | lint | 88.8% | Yes |
+| `docker build (20 steps)` | build | 87.7% | Yes |
+| `ruff check (110 violations, 4 rules)` | lint | 87.4% | Yes |
+| `git log --oneline (50 entries, already compact)` | git | 79.4% | Yes |
+| `git diff (5 files, 20 context lines each)` | git | 75.9% | Yes |
+| `find . -name '*.py' (205 results)` | file_listing | 75.1% | Yes |
+| `npm audit (15 vulnerabilities)` | build | 72.9% | Yes |
+| `ls (126 items)` | file_listing | 57.0% | Yes |
+| `mypy (30 errors, 5 rules)` | lint | 54.8% | Yes |
+| `git status (30+ files, verbose format)` | git | 32.7% | Yes |
+| `cat large_file.py (1000 lines)` | file_content | 0.0% | No |
+| `git status -s (45 files, short format)` | git | 0.0% | No |
+| `tsc (7 type errors)` | build | 0.0% | No |
+
+## Reading the zero-percent rows
+
+Three scenarios above show 0% deliberately, not as a bug:
+
+- **`cat large_file.py`** — source code passes through unchanged. Token-Saver
+  intercepts shell commands, not the model's own file-reading tool, and it
+  will not risk truncating code the model needs verbatim.
+- **`git status -s`** — the short format is already as dense as the
+  information it carries; there is nothing left to remove.
+- **`tsc` (7 type errors)** — a handful of type errors is already the signal,
+  not the noise. Compressing it further would risk dropping an error.
+
+Token-Saver returns the original bytes in these cases rather than shaving a
+few tokens at the cost of correctness. See
+[Precision Guarantees](https://github.com/ppgranger/token-saver/blob/main/README.md#precision-guarantees)
+for how that's enforced across all 36 processors.
+
+## See also
+
+- [How Token-Saver Compares](comparison.md) — the same rigor applied to
+  competing approaches (LLM summarization, blind truncation, caching).
+- [Processor reference](processors/) — per-tool documentation of what each
+  processor keeps and drops.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,3 +1,9 @@
+---
+title: How Token-Saver Compares
+description: Token-Saver vs cc_token_saver_mcp, token-optimizer-mcp, and Claude Context Mode — approach, latency, offline support, and whether they can run together.
+permalink: /comparison/
+---
+
 # How Token-Saver Compares
 
 Token-Saver focuses specifically on **command output compression** — it doesn't cache, delegate, or summarize via LLM. The tools below solve adjacent but different problems, and in many cases can be used alongside Token-Saver.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,141 @@
+---
+title: FAQ
+description: Answers on privacy, precision guarantees, platform support, and how Token-Saver behaves when it fails.
+permalink: /faq/
+---
+
+# FAQ
+
+## Does Token-Saver send my code or output to any server?
+
+No. Compression is entirely local — regex and string parsing in Python's
+standard library. The only network call is an optional GitHub release check,
+cached for 24 hours and silently skipped offline.
+
+## Will it hide an error from me or from the model?
+
+That's the failure mode the whole design is built around. Errors, stack
+traces, and non-zero exits are preserved; a failing command routes around
+processors that haven't proven they handle failure; dropped error lines are
+re-appended by the engine; and a test suite runs a failing fixture through
+every processor at every exit code to prove it. Truncation, when it happens,
+is always explicitly marked.
+
+## How much will I actually save?
+
+It depends entirely on which commands your agent runs. Sessions dominated by
+test runs and installs see the high end (90%+); sessions dominated by
+careful `git diff` reading see 40-70%. Run `token-saver stats` after a day
+of normal use for your real number, or `token-saver benchmark '<command>'`
+for a specific one. See [Benchmarks](benchmarks.md) for the full measured
+set.
+
+## Does it work with the Claude API or the Claude Agent SDK directly?
+
+Not as a drop-in — Token-Saver ships as a Claude Code plugin and an
+Antigravity CLI plugin. But the engine is importable (`from src.engine
+import CompressionEngine`) and has no dependency on either platform, so
+wiring it into your own agent loop is a few lines.
+
+## Does it work on Windows?
+
+Yes. Windows is a supported platform, with a `token-saver.cmd` launcher, an
+`%APPDATA%`-based data directory, and UTF-8 stdio forcing at every entry
+point.
+
+## Does it slow down my shell?
+
+No — Token-Saver only runs inside your AI assistant's tool calls. Your
+interactive terminal is untouched.
+
+## What happens if Token-Saver crashes?
+
+The hook fails open: the original command runs, uncompressed, exactly as it
+would without Token-Saver installed. Same for a Python error, a missing
+file, or a timeout.
+
+## Can I use it alongside other token-reduction MCP servers?
+
+Yes. Token-Saver operates at the output level; caching and delegation tools
+operate at the task or invocation level. See
+[How Token-Saver Compares](comparison.md).
+
+## Why not just tell the model "be brief", or pipe through `| tail -50`?
+
+Because the model doesn't control tool output, and `tail -50` doesn't know
+the error was on line 12. Format-aware compression keeps the 12 lines that
+matter out of 500 — blind truncation keeps the last 50 and hopes.
+
+## Does it compress files Claude reads with the Read tool?
+
+No. Token-Saver intercepts Bash commands; reads via the native file tool
+don't pass through it. It does handle `cat`, `head`, `tail`, and `bat` run
+as shell commands — though source code files pass through unchanged by
+design.
+
+## Can a repository I clone attack me through `.token-saver.json`?
+
+Not through the three keys that would matter. `user_processors_dir`
+(arbitrary code execution), `disabled_processors`, and
+`redaction_allowlist` are all rejected from project-level config. The rest
+are numeric thresholds with no code path to abuse.
+
+## How do I turn it off temporarily?
+
+`export TOKEN_SAVER_ENABLED=false`, or set `{"enabled": false}` in
+`~/.token-saver/config.json`.
+
+## Is a specific processor's behavior documented anywhere?
+
+Yes — the [processor reference](index.md#processors) has a page per
+processor covering what it matches, what it keeps, what it drops, and its
+config knobs.
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Does Token-Saver send my code or output to any server?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Compression is entirely local, using regex and string parsing in Python's standard library. The only network call is an optional GitHub release check, cached for 24 hours and silently skipped offline."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will it hide an error from me or from the model?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Errors, stack traces, and non-zero exits are preserved by design; a failing command routes around processors that haven't proven they handle failure, and a test suite verifies this at every exit code."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How much will Token-Saver actually save?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "It depends on which commands are run. Sessions dominated by test runs and installs see 90%+ savings; sessions dominated by git diff reading see 40-70%."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Token-Saver work with the Claude API or Claude Agent SDK directly?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Not as a drop-in plugin, but the compression engine is importable as a Python module and has no dependency on Claude Code or Antigravity CLI."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What happens if Token-Saver crashes?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The hook fails open: the original, uncompressed command output is returned exactly as it would be without Token-Saver installed."
+      }
+    }
+  ]
+}
+</script>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,77 @@
+---
+title: Token-Saver
+description: Content-aware output compression for AI coding assistants. 36 specialized processors cut CLI output tokens by 60-99% without losing errors, diffs, or stack traces.
+permalink: /
+---
+
+# Token-Saver
+
+**Content-aware output compression for AI coding assistants.**
+
+Token-Saver is a Claude Code and Antigravity CLI plugin that intercepts the
+verbose terminal output your agent reads — `git diff`, `pytest`, `npm
+install`, `terraform plan`, `kubectl` — and compresses it deterministically
+before it reaches the model. 36 specialized processors understand the shape
+of each tool's output, so errors, diffs, and stack traces survive while
+progress bars, passing tests, and installation logs are dropped.
+
+No LLM calls. No network access. Fully offline and deterministic — the same
+input always produces the same output.
+
+## Results
+
+| Command | Raw Output | Compressed | Savings |
+|---|---|---|---|
+| `git diff` (5 files, 20 context lines each) | 2,270 tokens | 546 tokens | **76%** |
+| `pytest` (500 tests, 2 failures) | 6,744 tokens | 307 tokens | **95%** |
+| `npm install` (220 packages) | 3,843 tokens | 4 tokens | **99.9%** |
+| `cargo build` (120 crates) | 934 tokens | 21 tokens | **98%** |
+| `docker build` (20 steps) | 1,682 tokens | 207 tokens | **88%** |
+| `curl` download (100 progress lines) | 2,122 tokens | 0 tokens | **100%** |
+
+These six rows are a sample. The full set of 22 measured scenarios — sorted
+by ratio, with methodology and reproduction steps — is on the
+[Benchmarks](benchmarks.md) page, and it's gated by CI: a code change that
+makes any of them compress worse fails the build.
+
+## Install
+
+```bash
+/plugin marketplace add ppgranger/token-saver
+/plugin install token-saver
+```
+
+See the [full README](https://github.com/ppgranger/token-saver#installation)
+for manual installation, Antigravity CLI setup, and upgrading from v1.x.
+
+## Documentation
+
+- [Benchmarks](benchmarks.md) — every measured scenario, methodology, and how to reproduce them.
+- [How It Compares](comparison.md) — vs `cc_token_saver_mcp`, `token-optimizer-mcp`, and Claude Context Mode.
+- [FAQ](faq.md) — privacy, precision guarantees, platform support, and common questions.
+- [Processor reference](#processors) — what each of the 36 processors keeps and drops.
+
+## Processors
+
+One page per tool family, documenting exactly what's kept, what's dropped,
+and which config knobs are available:
+
+<ul>
+{% assign processors = site.pages | where_exp: "p", "p.permalink contains '/processors/'" | sort: "title" %}
+{% for p in processors %}
+  <li><a href="{{ p.url | relative_url }}">{{ p.title }}</a> — {{ p.description }}</li>
+{% endfor %}
+</ul>
+
+## Why It Exists
+
+Every CLI command an AI coding assistant runs burns tokens, and most of that
+output is noise. There are three common ways to attack this: summarize with
+another LLM (accurate-ish, costs a second inference call, non-deterministic),
+truncate blindly (free, but loses the one stack-trace line that mattered), or
+parse the format you already know. Token-Saver is the third approach,
+applied to 36 command families — deterministically, in milliseconds, with no
+extra inference cost.
+
+Source, issue tracker, and the complete README:
+[github.com/ppgranger/token-saver](https://github.com/ppgranger/token-saver).

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,55 @@
+# Token-Saver
+
+> Content-aware output compression for AI coding assistants. A Claude Code
+> and Antigravity CLI plugin that intercepts verbose CLI command output
+> (git, pytest, npm, terraform, kubectl, docker, and more) and compresses it
+> deterministically before it reaches the model, using 36 specialized
+> processors — one per tool family. No LLM calls, no network access,
+> fully offline. Typical savings: 60-99% per command, with all errors,
+> diffs, and stack traces preserved by design.
+
+## Start here
+
+- [Home](https://ppgranger.github.io/token-saver/): Overview and quick start.
+- [Benchmarks](https://ppgranger.github.io/token-saver/benchmarks/): 22 measured compression scenarios, gated by CI, with methodology.
+- [How It Compares](https://ppgranger.github.io/token-saver/comparison/): Token-Saver vs cc_token_saver_mcp, token-optimizer-mcp, Claude Context Mode.
+- [FAQ](https://ppgranger.github.io/token-saver/faq/): Common questions on privacy, precision, platform support.
+- [Full README](https://github.com/ppgranger/token-saver/blob/main/README.md): Installation, architecture, configuration reference.
+
+## Processors (one page per tool family)
+
+- [git](https://ppgranger.github.io/token-saver/processors/git/): status, diff, log, show, push/pull/fetch, branch, stash, blame.
+- [test_output](https://ppgranger.github.io/token-saver/processors/test_output/): pytest, jest, go test, cargo test and other test runners.
+- [lint_output](https://ppgranger.github.io/token-saver/processors/lint_output/): eslint, ruff, pylint, clippy, mypy and other linters.
+- [build_output](https://ppgranger.github.io/token-saver/processors/build_output/): Build tool output across major ecosystems.
+- [docker](https://ppgranger.github.io/token-saver/processors/docker/): Docker CLI and Docker Compose output.
+- [kubectl](https://ppgranger.github.io/token-saver/processors/kubectl/): kubectl and oc (OpenShift) commands.
+- [terraform](https://ppgranger.github.io/token-saver/processors/terraform/): Terraform and OpenTofu commands.
+- [cargo](https://ppgranger.github.io/token-saver/processors/cargo/): Rust's cargo build system.
+- [cargo_clippy](https://ppgranger.github.io/token-saver/processors/cargo_clippy/): Rust clippy lint output.
+- [go](https://ppgranger.github.io/token-saver/processors/go/): Go toolchain commands.
+- [maven_gradle](https://ppgranger.github.io/token-saver/processors/maven_gradle/): Maven and Gradle build output.
+- [python_install](https://ppgranger.github.io/token-saver/processors/python_install/): Python package installation output (pip).
+- [package_list](https://ppgranger.github.io/token-saver/processors/package_list/): pip list, npm ls, and other package listing commands.
+- [helm](https://ppgranger.github.io/token-saver/processors/helm/): Helm CLI output for chart management.
+- [ansible](https://ppgranger.github.io/token-saver/processors/ansible/): ansible-playbook and ansible command output.
+- [cloud_cli](https://ppgranger.github.io/token-saver/processors/cloud_cli/): aws, gcloud, az and other cloud provider CLIs.
+- [gh](https://ppgranger.github.io/token-saver/processors/gh/): GitHub CLI (gh) output.
+- [db_query](https://ppgranger.github.io/token-saver/processors/db_query/): Database query result output.
+- [jq_yq](https://ppgranger.github.io/token-saver/processors/jq_yq/): Large JSON/YAML output from jq and yq.
+- [network](https://ppgranger.github.io/token-saver/processors/network/): HTTP client output (curl, wget).
+- [search](https://ppgranger.github.io/token-saver/processors/search/): grep, find, ripgrep output.
+- [file_listing](https://ppgranger.github.io/token-saver/processors/file_listing/): Directory listing commands (ls, tree, find).
+- [file_content](https://ppgranger.github.io/token-saver/processors/file_content/): Content-aware compression for file viewing commands.
+- [ssh](https://ppgranger.github.io/token-saver/processors/ssh/): Non-interactive SSH and SCP output.
+- [structured_log](https://ppgranger.github.io/token-saver/processors/structured_log/): JSON Lines log output from log tailing tools.
+- [syslog](https://ppgranger.github.io/token-saver/processors/syslog/): journalctl and dmesg output.
+- [system_info](https://ppgranger.github.io/token-saver/processors/system_info/): Disk and file counting commands.
+- [env](https://ppgranger.github.io/token-saver/processors/env/): Environment variable listing commands.
+- [generic](https://ppgranger.github.io/token-saver/processors/generic/): Fallback processor for unrecognized commands.
+
+## Optional
+
+- [Source repository](https://github.com/ppgranger/token-saver): Full source, issue tracker, releases.
+- [Custom Processors Guide](https://github.com/ppgranger/token-saver/blob/main/examples/custom_processor/README.md): How to write and register your own processor.
+- [License](https://github.com/ppgranger/token-saver/blob/main/LICENSE): Apache-2.0.

--- a/docs/processors/ansible.md
+++ b/docs/processors/ansible.md
@@ -1,3 +1,9 @@
+---
+title: Ansible Processor
+description: Handles `ansible-playbook` and `ansible` command output.
+permalink: /processors/ansible/
+---
+
 # Ansible Processor
 
 **File:** `src/processors/ansible.py` | **Priority:** 40 | **Name:** `ansible`

--- a/docs/processors/build_output.md
+++ b/docs/processors/build_output.md
@@ -1,3 +1,9 @@
+---
+title: Build Output Processor
+description: Handles build tool output across all major ecosystems.
+permalink: /processors/build_output/
+---
+
 # Build Output Processor
 
 **File:** `src/processors/build_output.py` | **Priority:** 25 | **Name:** `build`

--- a/docs/processors/cargo.md
+++ b/docs/processors/cargo.md
@@ -1,3 +1,9 @@
+---
+title: Cargo Processor
+description: Dedicated processor for Rust's cargo build system.
+permalink: /processors/cargo/
+---
+
 # Cargo Processor
 
 **File:** `src/processors/cargo.py` | **Priority:** 22 | **Name:** `cargo`

--- a/docs/processors/cargo_clippy.md
+++ b/docs/processors/cargo_clippy.md
@@ -1,3 +1,9 @@
+---
+title: Cargo Clippy Processor
+description: Dedicated processor for Rust clippy lint output with multi-line block awareness.
+permalink: /processors/cargo_clippy/
+---
+
 # Cargo Clippy Processor
 
 **File:** `src/processors/cargo_clippy.py` | **Priority:** 26 | **Name:** `cargo_clippy`

--- a/docs/processors/cloud_cli.md
+++ b/docs/processors/cloud_cli.md
@@ -1,3 +1,9 @@
+---
+title: Cloud CLI Processor
+description: Handles cloud provider CLI output.
+permalink: /processors/cloud_cli/
+---
+
 # Cloud CLI Processor
 
 **File:** `src/processors/cloud_cli.py` | **Priority:** 39 | **Name:** `cloud_cli`

--- a/docs/processors/db_query.md
+++ b/docs/processors/db_query.md
@@ -1,3 +1,9 @@
+---
+title: Database Query Processor
+description: Handles database query result output.
+permalink: /processors/db_query/
+---
+
 # Database Query Processor
 
 **File:** `src/processors/db_query.py` | **Priority:** 38 | **Name:** `db_query`

--- a/docs/processors/docker.md
+++ b/docs/processors/docker.md
@@ -1,3 +1,9 @@
+---
+title: Docker Processor
+description: Handles Docker CLI and Docker Compose output. Supports global options (`--context`, `-H`, `--host`).
+permalink: /processors/docker/
+---
+
 # Docker Processor
 
 **File:** `src/processors/docker.py` | **Priority:** 31 | **Name:** `docker`

--- a/docs/processors/env.md
+++ b/docs/processors/env.md
@@ -1,3 +1,9 @@
+---
+title: Environment Processor
+description: Handles environment variable listing commands.
+permalink: /processors/env/
+---
+
 # Environment Processor
 
 **File:** `src/processors/env.py` | **Priority:** 34 | **Name:** `env`

--- a/docs/processors/file_content.md
+++ b/docs/processors/file_content.md
@@ -1,3 +1,9 @@
+---
+title: File Content Processor
+description: Content-aware compression for file viewing commands. Instead of blind head/tail truncation, detects content type and applies a specialized strategy.
+permalink: /processors/file_content/
+---
+
 # File Content Processor
 
 **File:** `src/processors/file_content.py` | **Priority:** 51 | **Name:** `file_content`

--- a/docs/processors/file_listing.md
+++ b/docs/processors/file_listing.md
@@ -1,3 +1,9 @@
+---
+title: File Listing Processor
+description: Handles directory listing commands.
+permalink: /processors/file_listing/
+---
+
 # File Listing Processor
 
 **File:** `src/processors/file_listing.py` | **Priority:** 50 | **Name:** `file_listing`

--- a/docs/processors/generic.md
+++ b/docs/processors/generic.md
@@ -1,3 +1,9 @@
+---
+title: Generic Processor (Fallback)
+description: Universal fallback processor. Applies to any command not recognized by specialized processors, and also serves as a second-pass cleaner after specialized processors.
+permalink: /processors/generic/
+---
+
 # Generic Processor (Fallback)
 
 **File:** `src/processors/generic.py` | **Priority:** 999 | **Name:** `generic`

--- a/docs/processors/gh.md
+++ b/docs/processors/gh.md
@@ -1,3 +1,9 @@
+---
+title: GitHub CLI Processor
+description: Handles GitHub CLI (`gh`) output.
+permalink: /processors/gh/
+---
+
 # GitHub CLI Processor
 
 **File:** `src/processors/gh.py` | **Priority:** 37 | **Name:** `gh`

--- a/docs/processors/git.md
+++ b/docs/processors/git.md
@@ -1,3 +1,9 @@
+---
+title: Git Processor
+description: Handles all common git subcommands, including those with global options (`-C`, `--no-pager`, `-c`, `--git-dir`, `--work-tree`).
+permalink: /processors/git/
+---
+
 # Git Processor
 
 **File:** `src/processors/git.py` | **Priority:** 20 | **Name:** `git`

--- a/docs/processors/go.md
+++ b/docs/processors/go.md
@@ -1,3 +1,9 @@
+---
+title: Go Processor
+description: Dedicated processor for Go toolchain commands.
+permalink: /processors/go/
+---
+
 # Go Processor
 
 **File:** `src/processors/go.py` | **Priority:** 23 | **Name:** `go`

--- a/docs/processors/helm.md
+++ b/docs/processors/helm.md
@@ -1,3 +1,9 @@
+---
+title: Helm Processor
+description: Handles Helm CLI output for chart management operations.
+permalink: /processors/helm/
+---
+
 # Helm Processor
 
 **File:** `src/processors/helm.py` | **Priority:** 41 | **Name:** `helm`

--- a/docs/processors/jq_yq.md
+++ b/docs/processors/jq_yq.md
@@ -1,3 +1,9 @@
+---
+title: JQ/YQ Processor
+description: Compresses large JSON and YAML outputs from jq and yq.
+permalink: /processors/jq_yq/
+---
+
 # JQ/YQ Processor
 
 **File:** `src/processors/jq_yq.py` | **Priority:** 44 | **Name:** `jq_yq`

--- a/docs/processors/kubectl.md
+++ b/docs/processors/kubectl.md
@@ -1,3 +1,9 @@
+---
+title: Kubernetes Processor
+description: Handles kubectl and oc (OpenShift) commands. Supports global options (`-n`, `--namespace`, `--context`, `-A`, `--all-namespaces`, `--kubeconfig`).
+permalink: /processors/kubectl/
+---
+
 # Kubernetes Processor
 
 **File:** `src/processors/kubectl.py` | **Priority:** 32 | **Name:** `kubectl`

--- a/docs/processors/lint_output.md
+++ b/docs/processors/lint_output.md
@@ -1,3 +1,9 @@
+---
+title: Lint Output Processor
+description: Handles linter and static analysis output.
+permalink: /processors/lint_output/
+---
+
 # Lint Output Processor
 
 **File:** `src/processors/lint_output.py` | **Priority:** 27 | **Name:** `lint`

--- a/docs/processors/maven_gradle.md
+++ b/docs/processors/maven_gradle.md
@@ -1,3 +1,9 @@
+---
+title: Maven/Gradle Processor
+description: Dedicated processor for Maven and Gradle build output.
+permalink: /processors/maven_gradle/
+---
+
 # Maven/Gradle Processor
 
 **File:** `src/processors/maven_gradle.py` | **Priority:** 28 | **Name:** `maven_gradle`

--- a/docs/processors/network.md
+++ b/docs/processors/network.md
@@ -1,3 +1,9 @@
+---
+title: Network Processor
+description: Handles HTTP client output.
+permalink: /processors/network/
+---
+
 # Network Processor
 
 **File:** `src/processors/network.py` | **Priority:** 30 | **Name:** `network`

--- a/docs/processors/package_list.md
+++ b/docs/processors/package_list.md
@@ -1,3 +1,9 @@
+---
+title: Package List Processor
+description: Handles package listing commands. Runs at high priority (15) to intercept `pip list`/`npm ls` before the build processor.
+permalink: /processors/package_list/
+---
+
 # Package List Processor
 
 **File:** `src/processors/package_list.py` | **Priority:** 15 | **Name:** `package_list`

--- a/docs/processors/python_install.md
+++ b/docs/processors/python_install.md
@@ -1,3 +1,9 @@
+---
+title: Python Install Processor
+description: Dedicated processor for Python package installation output.
+permalink: /processors/python_install/
+---
+
 # Python Install Processor
 
 **File:** `src/processors/python_install.py` | **Priority:** 24 | **Name:** `python_install`

--- a/docs/processors/search.md
+++ b/docs/processors/search.md
@@ -1,3 +1,9 @@
+---
+title: Search Processor
+description: Handles search tool output.
+permalink: /processors/search/
+---
+
 # Search Processor
 
 **File:** `src/processors/search.py` | **Priority:** 35 | **Name:** `search`

--- a/docs/processors/ssh.md
+++ b/docs/processors/ssh.md
@@ -1,3 +1,9 @@
+---
+title: SSH Processor
+description: Handles non-interactive SSH and SCP command output.
+permalink: /processors/ssh/
+---
+
 # SSH Processor
 
 **File:** `src/processors/ssh.py` | **Priority:** 43 | **Name:** `ssh`

--- a/docs/processors/structured_log.md
+++ b/docs/processors/structured_log.md
@@ -1,3 +1,9 @@
+---
+title: Structured Log Processor
+description: Processor for JSON Lines log output from log tailing tools.
+permalink: /processors/structured_log/
+---
+
 # Structured Log Processor
 
 **File:** `src/processors/structured_log.py` | **Priority:** 45 | **Name:** `structured_log`

--- a/docs/processors/syslog.md
+++ b/docs/processors/syslog.md
@@ -1,3 +1,9 @@
+---
+title: Syslog Processor
+description: Handles system log output from `journalctl` and `dmesg`.
+permalink: /processors/syslog/
+---
+
 # Syslog Processor
 
 **File:** `src/processors/syslog.py` | **Priority:** 42 | **Name:** `syslog`

--- a/docs/processors/system_info.md
+++ b/docs/processors/system_info.md
@@ -1,3 +1,9 @@
+---
+title: System Info Processor
+description: Handles disk and file counting commands.
+permalink: /processors/system_info/
+---
+
 # System Info Processor
 
 **File:** `src/processors/system_info.py` | **Priority:** 36 | **Name:** `system_info`

--- a/docs/processors/terraform.md
+++ b/docs/processors/terraform.md
@@ -1,3 +1,9 @@
+---
+title: Terraform Processor
+description: Handles Terraform and OpenTofu commands.
+permalink: /processors/terraform/
+---
+
 # Terraform Processor
 
 **File:** `src/processors/terraform.py` | **Priority:** 33 | **Name:** `terraform`

--- a/docs/processors/test_output.md
+++ b/docs/processors/test_output.md
@@ -1,3 +1,9 @@
+---
+title: Test Output Processor
+description: Handles test runner output across all major ecosystems.
+permalink: /processors/test_output/
+---
+
 # Test Output Processor
 
 **File:** `src/processors/test_output.py` | **Priority:** 21 | **Name:** `test`

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,54 @@
+# Token-Saver
+
+> Content-aware output compression for AI coding assistants. A Claude Code
+> and Antigravity CLI plugin that intercepts verbose CLI command output
+> (git, pytest, npm, terraform, kubectl, docker, and more) and compresses it
+> deterministically before it reaches the model, using 36 specialized
+> processors — one per tool family. No LLM calls, no network access,
+> fully offline. Typical savings: 60-99% per command, with all errors,
+> diffs, and stack traces preserved by design.
+
+## Start here
+
+- [README](https://github.com/ppgranger/token-saver/blob/main/README.md): Full overview — installation, architecture, configuration, FAQ.
+- [Quick Start](https://github.com/ppgranger/token-saver/blob/main/README.md#quick-start): Install via `/plugin marketplace add ppgranger/token-saver`.
+- [Benchmarks](https://github.com/ppgranger/token-saver/blob/main/docs/benchmarks.md): 22 measured compression scenarios, gated by CI, with methodology.
+- [How It Compares](https://github.com/ppgranger/token-saver/blob/main/docs/comparison.md): Token-Saver vs cc_token_saver_mcp, token-optimizer-mcp, Claude Context Mode.
+
+## Processors (one page per tool family)
+
+- [git](https://github.com/ppgranger/token-saver/blob/main/docs/processors/git.md): status, diff, log, show, push/pull/fetch, branch, stash, blame.
+- [test_output](https://github.com/ppgranger/token-saver/blob/main/docs/processors/test_output.md): pytest, jest, go test, cargo test and other test runners.
+- [lint_output](https://github.com/ppgranger/token-saver/blob/main/docs/processors/lint_output.md): eslint, ruff, pylint, clippy, mypy and other linters.
+- [build_output](https://github.com/ppgranger/token-saver/blob/main/docs/processors/build_output.md): Build tool output across major ecosystems.
+- [docker](https://github.com/ppgranger/token-saver/blob/main/docs/processors/docker.md): Docker CLI and Docker Compose output.
+- [kubectl](https://github.com/ppgranger/token-saver/blob/main/docs/processors/kubectl.md): kubectl and oc (OpenShift) commands.
+- [terraform](https://github.com/ppgranger/token-saver/blob/main/docs/processors/terraform.md): Terraform and OpenTofu commands.
+- [cargo](https://github.com/ppgranger/token-saver/blob/main/docs/processors/cargo.md): Rust's cargo build system.
+- [cargo_clippy](https://github.com/ppgranger/token-saver/blob/main/docs/processors/cargo_clippy.md): Rust clippy lint output.
+- [go](https://github.com/ppgranger/token-saver/blob/main/docs/processors/go.md): Go toolchain commands.
+- [maven_gradle](https://github.com/ppgranger/token-saver/blob/main/docs/processors/maven_gradle.md): Maven and Gradle build output.
+- [python_install](https://github.com/ppgranger/token-saver/blob/main/docs/processors/python_install.md): Python package installation output (pip).
+- [package_list](https://github.com/ppgranger/token-saver/blob/main/docs/processors/package_list.md): pip list, npm ls, and other package listing commands.
+- [helm](https://github.com/ppgranger/token-saver/blob/main/docs/processors/helm.md): Helm CLI output for chart management.
+- [ansible](https://github.com/ppgranger/token-saver/blob/main/docs/processors/ansible.md): ansible-playbook and ansible command output.
+- [cloud_cli](https://github.com/ppgranger/token-saver/blob/main/docs/processors/cloud_cli.md): aws, gcloud, az and other cloud provider CLIs.
+- [gh](https://github.com/ppgranger/token-saver/blob/main/docs/processors/gh.md): GitHub CLI (gh) output.
+- [db_query](https://github.com/ppgranger/token-saver/blob/main/docs/processors/db_query.md): Database query result output.
+- [jq_yq](https://github.com/ppgranger/token-saver/blob/main/docs/processors/jq_yq.md): Large JSON/YAML output from jq and yq.
+- [network](https://github.com/ppgranger/token-saver/blob/main/docs/processors/network.md): HTTP client output (curl, wget).
+- [search](https://github.com/ppgranger/token-saver/blob/main/docs/processors/search.md): grep, find, ripgrep output.
+- [file_listing](https://github.com/ppgranger/token-saver/blob/main/docs/processors/file_listing.md): Directory listing commands (ls, tree, find).
+- [file_content](https://github.com/ppgranger/token-saver/blob/main/docs/processors/file_content.md): Content-aware compression for file viewing commands.
+- [ssh](https://github.com/ppgranger/token-saver/blob/main/docs/processors/ssh.md): Non-interactive SSH and SCP output.
+- [structured_log](https://github.com/ppgranger/token-saver/blob/main/docs/processors/structured_log.md): JSON Lines log output from log tailing tools.
+- [syslog](https://github.com/ppgranger/token-saver/blob/main/docs/processors/syslog.md): journalctl and dmesg output.
+- [system_info](https://github.com/ppgranger/token-saver/blob/main/docs/processors/system_info.md): Disk and file counting commands.
+- [env](https://github.com/ppgranger/token-saver/blob/main/docs/processors/env.md): Environment variable listing commands.
+- [generic](https://github.com/ppgranger/token-saver/blob/main/docs/processors/generic.md): Fallback processor for unrecognized commands.
+
+## Optional
+
+- [Custom Processors Guide](https://github.com/ppgranger/token-saver/blob/main/examples/custom_processor/README.md): How to write and register your own processor.
+- [Contributing](https://github.com/ppgranger/token-saver/blob/main/CONTRIBUTING.md): Development setup, test suite, PR conventions.
+- [License](https://github.com/ppgranger/token-saver/blob/main/LICENSE): Apache-2.0.

--- a/tests/test_processor_count_consistency.py
+++ b/tests/test_processor_count_consistency.py
@@ -1,0 +1,81 @@
+"""One processor count, discovered once, asserted everywhere.
+
+``src/processors/discover_processors()`` is the source of truth. But the
+processor count is also *hand-typed* into five other places for marketing/doc
+purposes — README, docs/comparison.md, the config skill, and the two plugin
+manifests — and nothing kept them honest: plugin.json and marketplace.json
+drifted to "32" while everything else said "36" and the registry actually
+returns 36. A stale count in a plugin manifest is visible to users browsing
+the Claude Code marketplace, and public docs sites (and the LLMs that cite
+them) will happily propagate whichever number they scrape first.
+
+Adding, removing, or splitting a processor is therefore: run this test, fix
+whatever it names.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.processors import discover_processors
+
+REPO_ROOT = pathlib.Path(__file__).parent.parent
+
+
+def _processor_count() -> int:
+    return len(discover_processors())
+
+
+def _text(rel: str) -> str:
+    return (REPO_ROOT / rel).read_text(encoding="utf-8")
+
+
+def _json(rel: str) -> dict:
+    return json.loads(_text(rel))
+
+
+@pytest.mark.parametrize(
+    ("rel", "pattern"),
+    [
+        ("README.md", r"\*\*(\d+) specialized processors\*\*"),
+        ("docs/comparison.md", r"\| \*\*Compression method\*\* \| (\d+) specialized processors"),
+        ("skills/token-saver-config/SKILL.md", r"(\d+) specialized processors, auto-discovered"),
+    ],
+)
+def test_doc_processor_count_matches_registry(rel, pattern):
+    match = re.search(pattern, _text(rel))
+    assert match, f"{rel} does not contain the expected processor-count phrase"
+    assert int(match.group(1)) == _processor_count(), (
+        f"{rel} says {match.group(1)} processors but "
+        f"discover_processors() returns {_processor_count()}"
+    )
+
+
+def test_plugin_manifest_processor_count_matches_registry():
+    description = _json(".claude-plugin/plugin.json")["description"]
+    match = re.search(r"(\d+) specialized processors", description)
+    assert match, ".claude-plugin/plugin.json description has no processor count"
+    assert int(match.group(1)) == _processor_count(), (
+        f".claude-plugin/plugin.json says {match.group(1)} processors but "
+        f"discover_processors() returns {_processor_count()}"
+    )
+
+
+def test_marketplace_catalog_processor_count_matches_registry():
+    for entry in _json(".claude-plugin/marketplace.json")["plugins"]:
+        match = re.search(r"(\d+) specialized processors", entry["description"])
+        if not match:
+            continue
+        assert int(match.group(1)) == _processor_count(), (
+            f".claude-plugin/marketplace.json plugin {entry.get('name')!r} says "
+            f"{match.group(1)} processors but discover_processors() returns "
+            f"{_processor_count()}"
+        )


### PR DESCRIPTION
## What

1. **Fix**: plugin manifests said 32 processors; `discover_processors()` returns 36, matching every other doc. Added `test_processor_count_consistency.py` (mirrors the existing `test_version_consistency.py` pattern) so this can't drift silently again.
2. **GEO groundwork**: give the existing `docs/processors/*.md` content and the CI-gated compression baselines actual indexable URLs.
   - `llms.txt` (root + `docs/`)
   - `docs/benchmarks.md` — the 22 scenarios from `tests/compression_baselines.json`, with methodology
   - Jekyll front matter (`title`/`description`/`permalink`) on all 29 processor docs + `comparison.md` — body content untouched
3. **Pages scaffold**: `docs/_config.yml` (minima theme, no custom Actions build needed), `docs/index.md`, `docs/faq.md`, and `docs/_includes/head-custom.html` (meta description + JSON-LD: `SoftwareApplication` on home, `TechArticle` on processor/benchmark/comparison pages, `FAQPage` on the FAQ) — using minima's own `<head>` extension point rather than forking the theme layout.

## Why

The repo has zero indexable surface outside GitHub's blob viewer — no Pages, empty `homepage`, no topics. AI/search crawlers barely index `github.com/*/blob/*`, so ~1,000 lines of already-written technical docs and a CI-gated benchmark table are effectively invisible. This is Phase A+B of a larger GEO plan; Phase C (repo topics, description, homepage, enabling Pages/Discussions) is outward-facing and will be proposed separately for explicit confirmation before running.

## Verification

- `python3 -m pytest tests/` → 1369 passed, 12 skipped, no regressions
- All new/modified front matter validated as parseable YAML
- All 3 JSON-LD blocks (`SoftwareApplication`, `TechArticle`, `FAQPage`) validated as well-formed JSON
- Not yet live: GitHub Pages isn't enabled at the repo level, so this PR has no outward-facing effect until Phase C