### PR TITLE
fix: minima never included our custom <head> partial (wrong filename)

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,6 +1,11 @@
 theme: minima
 
 title: Token-Saver
+# jekyll-seo-tag builds <title> as "page.title | site.tagline" and only
+# falls back to the full site.description when tagline is unset — which is
+# what produced a <title> that was the whole paragraph below. Keep tagline
+# short; description stays long-form for <meta name="description"> and og:.
+tagline: Content-aware output compression for AI coding assistants
 description: >-
   Content-aware output compression for AI coding assistants. 36 specialized
   processors compress verbose CLI output (git, pytest, npm, terraform,

--- a/docs/_includes/custom-head.html
+++ b/docs/_includes/custom-head.html
@@ -1,14 +1,16 @@
 <!--
-  minima's own `head.html` includes this file if present — this is the
-  theme's sanctioned extension point for <head> additions, so we don't have
-  to fork the whole default layout just to inject a meta description and
-  JSON-LD. Keeping it here means theme/gem updates never conflict with this
-  file.
--->
+  minima's own `head.html` includes this file (named exactly
+  "custom-head.html" — that's the theme's sanctioned extension point) at the
+  end of <head>, so we don't have to fork the whole default layout just to
+  add JSON-LD. Keeping it here means theme/gem updates never conflict with
+  this file.
 
-{% if page.description %}
-<meta name="description" content="{{ page.description | strip_html | strip_newlines | escape }}">
-{% endif %}
+  No <meta name="description"> here: jekyll-seo-tag (bundled by the
+  github-pages gem and invoked via {% seo %} earlier in head.html) already
+  emits it from page.description/site.description, and jekyll-relative-links
+  is a Pages-whitelisted plugin too — duplicating the tag here would just
+  produce two conflicting <meta name="description"> elements.
+-->
 
 {% if page.url == "/" %}
 <script type="application/ld+json">


### PR DESCRIPTION
## What broke

Live-checked https://ppgranger.github.io/token-saver/ right after enabling Pages — my earlier validation only parsed the YAML/JSON locally, never rendered a real Jekyll build.

Two bugs found in prod:

1. **`docs/_includes/head-custom.html` was never included.** minima's `head.html` includes a file named `custom-head.html`, not `head-custom.html`. Wrong name meant Jekyll silently skipped it — no JSON-LD, no meta description from our file ever rendered. Renamed to match.
2. **Would-be duplicate `<meta name="description">`.** Once actually included, our file would have emitted a second description tag — `jekyll-seo-tag` (bundled by the `github-pages` gem, invoked via `{% seo %}`) already renders one from `page.description`/`site.description`. Removed ours; kept the JSON-LD (`SoftwareApplication`/`TechArticle`), which `jekyll-seo-tag` doesn't provide.
3. **Bonus find while diagnosing:** without `site.tagline` set, `jekyll-seo-tag` built `<title>` as the site name followed by the *entire* long-form `site.description` (its documented fallback behavior). Added a short `tagline` in `_config.yml` so `<title>` stays "Token-Saver | Content-aware output compression for AI coding assistants" instead of the whole paragraph.

## Verification

- `_config.yml` re-validated as parseable YAML
- JSON-LD blocks re-validated as well-formed JSON (Liquid tags substituted)
- Will re-check the live site's rendered `<head>` after this merges and Pages rebuilds