### PR TITLE
fix: Liquid tags in HTML comment broke the homepage <head>

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -1,4 +1,4 @@
-<!--
+{% comment %}
   Full override of minima's _includes/head.html.
 
   minima ships a `custom-head.html` extension point, but only from some
@@ -11,10 +11,15 @@
   minima version Pages happens to be running.
 
   Everything up to the closing </head> mirrors minima 2.5.1's head.html
-  (meta tags, {% seo %}, stylesheet, feed_meta, conditional Google
-  Analytics) so nothing else regresses; the JSON-LD block is the only
-  addition.
--->
+  (meta tags, seo tag, stylesheet, feed_meta, conditional Google Analytics)
+  so nothing else regresses; the JSON-LD block is the only addition.
+
+  This has to be a Liquid {% comment %} block, not an HTML <!-- --> comment:
+  Liquid tags are evaluated wherever they appear, even inside HTML comments,
+  and {% seo %} below renders its own "<!-- End Jekyll SEO tag -->" — whose
+  "-->" would close an HTML comment early and leak the rest of this text
+  (plus a duplicate <head>) straight into the rendered page.
+{% endcomment %}
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
## What broke

The live homepage showed raw comment text above the actual page content:
> ", stylesheet, feed_meta, conditional Google Analytics) so nothing else regresses; the JSON-LD block is the only addition. -->"

## Root cause

`docs/_includes/head.html`'s explanatory header was an HTML `<!-- -->` comment that *mentioned* `{% seo %}` and `{%- feed_meta -%}` in prose. Liquid evaluates tags wherever they appear in a template, including inside HTML comments — it has no concept of "this is just descriptive text." `{% seo %}` renders its own `<!-- End Jekyll SEO tag -->`, and that tag's `-->` closed our HTML comment early. Everything after it — the rest of the explanation, then a second `<head>` — leaked straight into the rendered page as visible text, followed by a literal duplicate `<head>...</head>` in the DOM.

Confirmed by fetching the raw HTML (not just spot-checking `<meta>`/JSON-LD presence, which is what the earlier verification did):

```
<html lang="en"><!--
  Full override of minima's _includes/head.html.
  ...
  Everything up to the closing </head> mirrors minima 2.5.1's head.html
  (meta tags, <!-- Begin Jekyll SEO tag v2.8.0 -->
  ...
<!-- End Jekyll SEO tag -->
, stylesheet, feed_meta, conditional Google
  Analytics) so nothing else regresses; the JSON-LD block is the only
  addition.
-->
<head>
  ...                                    <!-- head.html's real content starts here, appearing a SECOND time -->
```

## Fix

Switched the header to a Liquid `{% comment %}...{% endcomment %}` block. Content inside is never parsed by the Liquid engine, so mentioning `{% seo %}` in prose is safe regardless of what that tag renders to elsewhere in the same file.

## Verification

- Will re-fetch the raw homepage HTML after this merges and Pages rebuilds to confirm the comment leak and duplicate `<head>` are gone — that's the check that caught this in the first place, `curl | grep` for expected fragments alone had missed it twice already on this file