### PR TITLE
fix: nested {% comment %} tag broke the Pages build entirely

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -14,11 +14,20 @@
   (meta tags, seo tag, stylesheet, feed_meta, conditional Google Analytics)
   so nothing else regresses; the JSON-LD block is the only addition.
 
-  This has to be a Liquid {% comment %} block, not an HTML <!-- --> comment:
-  Liquid tags are evaluated wherever they appear, even inside HTML comments,
-  and {% seo %} below renders its own "<!-- End Jekyll SEO tag -->" — whose
-  "-->" would close an HTML comment early and leak the rest of this text
-  (plus a duplicate <head>) straight into the rendered page.
+  Keep this a Liquid comment block, and never write Liquid tag syntax inside
+  it — not even as an example. Two separate outages came from ignoring that:
+
+  1. As an HTML comment, the seo tag named below still rendered (Liquid
+     evaluates tags anywhere, comments included). It emits its own HTML
+     end-comment marker, whose "--" + ">" closed this comment early and
+     leaked the remaining prose plus a duplicate head element into the page.
+  2. Rewritten as a Liquid comment, spelling out the opening comment tag in
+     prose opened a *nested* comment block, so the closing tag below matched
+     the inner one and the outer block was never closed. That's a hard build
+     failure: "Liquid syntax error: 'comment' tag was never closed".
+
+  Refer to tags by name only (seo tag, feed_meta, endcomment), never in
+  brace-percent form.
 {% endcomment %}
 <head>
   <meta charset="utf-8">


### PR DESCRIPTION
## What broke

The Pages build itself failed after #61 merged:

```
Error: Liquid syntax error (/github/workspace/docs/_includes/head.html line 79):
'comment' tag was never closed
```

The site is currently stuck serving whatever the last successful build was (the broken duplicate-`<head>` version from before #61), since a failed build doesn't update the deployed site.

## Root cause

#61 wrapped the header in `{% comment %}...{% endcomment %}` to stop Liquid tags rendering inside an HTML comment. But the explanatory prose *inside* that comment spelled out the literal tag `{% comment %}` as an example of what to use instead. Liquid comment blocks aren't comment-aware of their own contents — writing that tag string inside the block opens a **nested** comment, so the `{% endcomment %}` immediately after it closed the inner block, leaving the outer one unclosed for the rest of the file. Hard build failure.

Same underlying mistake as #61, one level deeper: don't write Liquid tag syntax as an example inside a Liquid comment, same as you can't write it as an example inside an HTML comment.

## Fix

Reworded the explanation to refer to tags by name in prose (\"the seo tag\", \"feed_meta\") without ever spelling out `{% %}` syntax inside the comment block, and documented both prior outages directly in the comment so this doesn't get reintroduced a third time.