### PR TITLE
docs: document installing from Anthropic's official community marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Not every command compresses, and that's deliberate. `cat large_file.py`, `git s
 /plugin install token-saver
 ```
 
+(Also available on Anthropic's official community marketplace — see [Installation](#installation) for both options.)
+
 That's the whole setup. Ask Claude to run anything — *"run the tests"*, *"show me the diff"*, *"what changed in the last 10 commits"* — and the output is compressed before it reaches the model. Then:
 
 ```bash
@@ -344,7 +346,16 @@ No third-party Python packages are required — Token-Saver uses only the standa
 
 ### Method 1: Claude Code Plugin (recommended)
 
-From the self-hosted marketplace:
+Two marketplaces carry Token-Saver — pick one.
+
+**Anthropic's official community marketplace** (`claude-community`), no setup beyond adding it once:
+```
+/plugin marketplace add anthropics/claude-plugins-community
+/plugin install token-saver@claude-community --scope project
+```
+This mirror is a snapshot pinned to a specific commit, refreshed periodically rather than on every push — if you want the exact latest commit on `main`, use the self-hosted marketplace below instead.
+
+**Self-hosted marketplace** (this repo, always current):
 ```
 /plugin marketplace add ppgranger/token-saver
 /plugin install token-saver
@@ -419,7 +430,10 @@ You can also run `token-saver update` from anywhere to auto-upgrade.
 ### Avoid dual installation
 
 Do NOT install token-saver via BOTH `/plugin install` AND `python3 install.py`
-simultaneously — this could register the plugin twice. Use one method or the other.
+simultaneously — this could register the plugin twice. Use one method or the
+other. The same applies across marketplaces: install from either
+`claude-community` or the self-hosted `ppgranger/token-saver` marketplace,
+not both.
 
 To switch from manual to marketplace:
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,16 @@ makes any of them compress worse fails the build.
 
 ## Install
 
+From Anthropic's official community marketplace:
+
+```bash
+/plugin marketplace add anthropics/claude-plugins-community
+/plugin install token-saver@claude-community --scope project
+```
+
+Or from the self-hosted marketplace (this repo, always current — the
+official mirror is a periodic snapshot):
+
 ```bash
 /plugin marketplace add ppgranger/token-saver
 /plugin install token-saver


### PR DESCRIPTION
## What

token-saver is already listed on `anthropics/claude-plugins-community` (the `claude-community` marketplace) — confirmed by fetching that repo's `marketplace.json` directly. Neither the README nor the Pages site mentioned this; the only documented install path was the self-hosted marketplace (this repo).

```
/plugin marketplace add anthropics/claude-plugins-community
/plugin install token-saver@claude-community --scope project
```

## Worth knowing: the official mirror is stale

The `claude-community` entry is pinned to commit `5ca09da` (Merge PR #55) — one merge before this session's processor-count fix (32→36). That's very likely the actual source of the "21 specialized processors" figure that showed up on claudeskills.info earlier in this thread: a third-party aggregator scraped the official marketplace's snapshot rather than this repo directly, at a point in its history where the count was even further off than our own 32-vs-36 drift.

Since I can't push updates to `anthropics/claude-plugins-community` from here, the README and Pages site now say so explicitly: use the self-hosted marketplace (this repo) if you want the exact current commit on `main`.

## Changes

- `README.md` Method 1: both marketplaces documented, with the staleness caveat
- `README.md` Quick Start: points to Installation for the choice
- `README.md` "Avoid dual installation": extended to cover mixing marketplaces, not just install methods
- `docs/index.md`: mirrors the same two-marketplace install block

## Verification

- `python3 -m pytest tests/` → 1369 passed, 12 skipped