### PR TITLE
chore: bump version to 2.7.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "token-saver",
       "source": "./",
       "description": "Automatically compresses verbose CLI output to save tokens. 36 specialized processors for git, docker, npm, terraform, kubectl, helm, ansible, cargo, go, and more.",
-      "version": "2.7.1",
+      "version": "2.7.2",
       "author": {
         "name": "ppgranger"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "token-saver",
   "description": "Automatically compresses verbose CLI output (git, docker, npm, terraform, kubectl, etc.) to save tokens in Claude Code sessions. 36 specialized processors with content-aware compression.",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "author": {
     "name": "ppgranger",
     "url": "https://github.com/ppgranger"

--- a/antigravity/antigravity-plugin.json
+++ b/antigravity/antigravity-plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "token-saver",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "description": "Compresses verbose tool outputs to save tokens while preserving critical information"
 }

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -6,7 +6,7 @@ permalink: /benchmarks/
 
 # Token-Saver Compression Benchmarks
 
-Version: **2.7.1** · Baselines last updated: **2026-08-02** · Source: [`tests/compression_baselines.json`](https://github.com/ppgranger/token-saver/blob/main/tests/compression_baselines.json)
+Version: **2.7.2** · Baselines last updated: **2026-08-02** · Source: [`tests/compression_baselines.json`](https://github.com/ppgranger/token-saver/blob/main/tests/compression_baselines.json)
 
 These are not marketing estimates. Every row below is a fixed baseline
 checked into the repository and enforced by

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-__version__ = "2.7.1"
+__version__ = "2.7.2"
 
 
 def data_dir() -> str:


### PR DESCRIPTION
## What

Bumps \`src/__init__.py\` (source of truth) to 2.7.2, plus the three manifests \`test_version_consistency.py\` checks against, plus \`docs/benchmarks.md\`'s displayed version (not covered by that test, but hand-maintained the same way).

## Verification

- \`python3 -m pytest tests/\` → 1369 passed, 12 skipped
- \`grep -rn "2\.7\.1"\` across the repo → no remaining references